### PR TITLE
Add Redis Keys Command to GraphQL

### DIFF
--- a/graphql-server/package.json
+++ b/graphql-server/package.json
@@ -13,16 +13,16 @@
   "dependencies": {
     "apollo-server": "^2.9.16",
     "graphql": "^14.6.0",
+    "graphql-scalars": "^1.0.6",
     "graphql-tag": "^2.10.1",
-    "graphql-type-json": "^0.3.1",
     "graphql-type-uuid": "^0.2.0",
     "ioredis": "^4.14.1",
+    "jsesc": "^2.5.2",
     "lodash": "^4.17.15",
     "uuid": "^3.3.3"
   },
   "devDependencies": {
     "@types/graphql": "^14.5.0",
-    "@types/graphql-type-json": "^0.3.2",
     "@types/graphql-type-uuid": "^0.2.3",
     "@types/ioredis": "^4.0.18",
     "@types/lodash": "^4.14.149",

--- a/graphql-server/src/adapters/redis.ts
+++ b/graphql-server/src/adapters/redis.ts
@@ -1,4 +1,4 @@
-import Redis from 'ioredis';
+import Redis from "ioredis";
 
 export const redisClient = new Redis();
 export const pubRedisClient = new Redis();

--- a/graphql-server/src/app.ts
+++ b/graphql-server/src/app.ts
@@ -22,6 +22,7 @@ const resolvers: IResolvers = {
   },
 
   ...rootResolver.scalars,
+  ...redisCommandResolvers.types,
   ...redisCommandResolvers.custom
 };
 

--- a/graphql-server/src/scopes/commands/index.ts
+++ b/graphql-server/src/scopes/commands/index.ts
@@ -39,6 +39,8 @@ export const resolvers = {
     ...keysCommandResolver.mutation
   },
   subscription: {},
+  types: {
+    ...keysCommandResolver.types
+  },
   custom: { ...customScalarResolver }
 };
-

--- a/graphql-server/src/scopes/commands/keys/del.ts
+++ b/graphql-server/src/scopes/commands/keys/del.ts
@@ -2,24 +2,24 @@ import gql from "graphql-tag";
 import { ResolverFunction, IntResp } from "@typings";
 import { redisClient } from "@adapters/redis";
 
-export type ExistsArg = {
+export type DelArg = {
   keys: string[];
 };
 
-export const _exists: ResolverFunction<ExistsArg> = async (
+export const _del: ResolverFunction<DelArg> = async (
   root,
   { keys },
   ctx
 ): Promise<IntResp> => {
-  const existNumber = await redisClient.exists(...keys);
+  const existNumber = await redisClient.del(...keys);
   return existNumber;
 };
 
 export const typeDefs = gql`
-  extend type Query {
+  extend type Mutation {
     """
-    Determine if a key exists. [Read more >>](https://redis.io/commands/exists)
+    Delete a key. [Read more >>](https://redis.io/commands/del)
     """
-    _exists(keys: [String!]!): Int
+    _del(keys: [String!]!): Int
   }
 `;

--- a/graphql-server/src/scopes/commands/keys/dump.ts
+++ b/graphql-server/src/scopes/commands/keys/dump.ts
@@ -1,0 +1,37 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+import jsesc from "jsesc";
+
+export type DelArg = {
+  key: string;
+};
+
+export const _dump: ResolverFunction<DelArg> = (
+  root,
+  { key },
+  ctx
+): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    // @ts-ignore
+    redisClient.dumpBuffer(key, function(err: Error, result: Buffer) {
+      if (err || result === null) return reject(err.message);
+      const dumpStringCodePoint = [];
+
+      for (const v of result.values()) {
+        dumpStringCodePoint.push(v);
+      }
+
+      return resolve(String.fromCodePoint(...dumpStringCodePoint));
+    });
+  });
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Return a serialized version of the value stored at the specified key. [Read more >>](https://redis.io/commands/dump)
+    """
+    _dump(key: String!): String
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/expire.ts
+++ b/graphql-server/src/scopes/commands/keys/expire.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type ExpireArg = {
+  key: string;
+  seconds: number;
+};
+
+export const _expire: ResolverFunction<ExpireArg> = async (
+  root,
+  { key, seconds },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.expire(key, seconds);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Set a key's time to live in seconds. [Read more >>](https://redis.io/commands/expire)
+    """
+    _expire(key: String!, seconds: Int!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/expireat.ts
+++ b/graphql-server/src/scopes/commands/keys/expireat.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type ExpireAtArg = {
+  key: string;
+  timestamp: number;
+};
+
+export const _expireat: ResolverFunction<ExpireAtArg> = async (
+  root,
+  { key, timestamp },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.expireat(key, timestamp);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Set the expiration for a key as a UNIX timestamp. [Read more >>](https://redis.io/commands/expireat)
+    """
+    _expireat(key: String!, timestamp: Int!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/index.ts
+++ b/graphql-server/src/scopes/commands/keys/index.ts
@@ -1,8 +1,80 @@
+import { typeDefs as delTypeDefs, _del } from "./del";
+import { typeDefs as dumpTypeDefs, _dump } from "./dump";
 import { typeDefs as existsTypeDefs, _exists } from "./exists";
+import { typeDefs as expireTypeDefs, _expire } from "./expire";
+import { typeDefs as expireAtTypeDefs, _expireat } from "./expireat";
+import { typeDefs as ttlTypeDefs, _ttl } from "./ttl";
+import { typeDefs as keysTypeDefs, _keys } from "./keys";
+import { typeDefs as moveTypeDefs, _move } from "./move";
+import { typeDefs as objectTypeDefs, _object } from "./object";
+import { typeDefs as persistTypeDefs, _persist } from "./persist";
+import { typeDefs as pexpireTypeDefs, _pexpire } from "./pexpire";
+import { typeDefs as pexpireAtTypeDefs, _pexpireat } from "./pexpireat";
+import { typeDefs as pttlTypeDefs, _pttl } from "./pttl";
+import { typeDefs as randomKeyTypeDefs, _randomkey } from "./randomkey";
+import { typeDefs as renameTypeDefs, _rename } from "./rename";
+import { typeDefs as renameNxTypeDefs, _renamenx } from "./renamenx";
+import { typeDefs as typeTypeDefs, _type } from "./type";
+import { typeDefs as touchTypeDefs, _touch } from "./touch";
+import { typeDefs as restoreTypeDefs, _restore } from "./restore";
+import { typeDefs as unlinkTypeDefs, _unlink } from "./unlink";
+import { typeDefs as waitTypeDefs, _wait } from "./wait";
+import { typeDefs as scanTypeDefs, typeResolvers as scanTypeResolvers, _scan } from "./scan";
 
-export const typeDefs = [existsTypeDefs];
+export const typeDefs = [
+  existsTypeDefs,
+  delTypeDefs,
+  dumpTypeDefs,
+  expireTypeDefs,
+  ttlTypeDefs,
+  expireAtTypeDefs,
+  keysTypeDefs,
+  moveTypeDefs,
+  objectTypeDefs,
+  persistTypeDefs,
+  pexpireTypeDefs,
+  pexpireAtTypeDefs,
+  pttlTypeDefs,
+  randomKeyTypeDefs,
+  renameTypeDefs,
+  renameNxTypeDefs,
+  typeTypeDefs,
+  touchTypeDefs,
+  restoreTypeDefs,
+  unlinkTypeDefs,
+  waitTypeDefs,
+  scanTypeDefs
+];
+
 export const resolvers = {
-  query: { _exists },
-  mutation: {},
-  subscription: {}
+  query: {
+    _exists,
+    _dump,
+    _ttl,
+    _keys,
+    _object,
+    _pttl,
+    _randomkey,
+    _type,
+    _scan
+  },
+  mutation: {
+    _del,
+    _expire,
+    _expireat,
+    _move,
+    _persist,
+    _pexpire,
+    _pexpireat,
+    _rename,
+    _renamenx,
+    _touch,
+    _restore,
+    _unlink,
+    _wait
+  },
+  subscription: {},
+  types: {
+    ...scanTypeResolvers
+  }
 };

--- a/graphql-server/src/scopes/commands/keys/keys.ts
+++ b/graphql-server/src/scopes/commands/keys/keys.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type KeysArg = {
+  pattern: string;
+};
+
+export const _keys: ResolverFunction<KeysArg> = async (
+  root,
+  { pattern },
+  ctx
+): Promise<string[]> => {
+  try {
+    const reply = await redisClient.keys(pattern);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Find all keys matching the given pattern. [Read more >>](https://redis.io/commands/keys)
+    """
+    _keys(pattern: String!): [String]
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/move.ts
+++ b/graphql-server/src/scopes/commands/keys/move.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type MoveArg = {
+  key: string;
+  db: string;
+};
+
+export const _move: ResolverFunction<MoveArg> = async (
+  root,
+  { key, db },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.move(key, db);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Move a key to another database. [Read more >>](https://redis.io/commands/move)
+    """
+    _move(key: String!, db: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/object.ts
+++ b/graphql-server/src/scopes/commands/keys/object.ts
@@ -1,0 +1,81 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export enum Subcommand {
+  REFCOUNT = "REFCOUNT",
+  ENCODING = "ENCODING",
+  IDLETIME = "IDLETIME",
+  FREQ = "FREQ",
+  HELP = "HELP"
+}
+
+export type ObjectArg = {
+  subcommand: Subcommand;
+  key?: string;
+};
+
+export const _object: ResolverFunction<ObjectArg> = async (
+  root,
+  { subcommand, key },
+  ctx
+): Promise<IntResp | string[]> => {
+  try {
+    const args = subcommand === Subcommand.HELP ? [] : [key];
+    const reply = await redisClient.object(subcommand, ...args);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  """
+  The OBJECT command supports multiple sub commands
+  """
+  enum Subcommand {
+    """
+    ### OBJECT REFCOUNT <key>
+    returns the number of references of the value associated with the specified key.
+    This command is mainly useful for debugging.
+    """
+    REFCOUNT
+
+    """
+    ### OBJECT ENCODING <key>
+    returns the kind of internal representation used in order to
+    store the value associated with a key.
+    """
+    ENCODING
+
+    """
+    ### OBJECT IDLETIME <key>
+    returns the number of seconds since the object stored at the specified key
+    is idle (not requested by read or write operations).
+    While the value is returned in seconds the actual resolution of this timer is 10 seconds,
+    but may vary in future implementations. This subcommand is available when
+    maxmemory-policy is set to an LRU policy or noeviction
+    """
+    IDLETIME
+
+    """
+    ### OBJECT FREQ <key>
+    returns the logarithmic access frequency counter of the object stored at the specified key.
+    This subcommand is available when maxmemory-policy is set to an LFU policy.
+    """
+    FREQ
+
+    """
+    ### OBJECT HELP
+    returns a succinct help text.
+    """
+    HELP
+  }
+
+  extend type Query {
+    """
+    Inspect the internals of Redis objects. [Read more >>](https://redis.io/commands/object)
+    """
+    _object(subcommand: Subcommand!, key: String): RespBulk
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/persist.ts
+++ b/graphql-server/src/scopes/commands/keys/persist.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type PersistArg = {
+  key: string;
+};
+
+export const _persist: ResolverFunction<PersistArg> = async (
+  root,
+  { key },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.persist(key);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Remove the expiration from a key. [Read more >>](https://redis.io/commands/persist)
+    """
+    _persist(key: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/pexpire.ts
+++ b/graphql-server/src/scopes/commands/keys/pexpire.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type PExpireArg = {
+  key: string;
+  milliseconds: number;
+};
+
+export const _pexpire: ResolverFunction<PExpireArg> = async (
+  root,
+  { key, milliseconds },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.pexpire(key, milliseconds);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Set a key's time to live in milliseconds. [Read more >>](https://redis.io/commands/pexpire)
+    """
+    _pexpire(key: String!, milliseconds: Int!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/pexpireat.ts
+++ b/graphql-server/src/scopes/commands/keys/pexpireat.ts
@@ -1,0 +1,35 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type PExpireAtArg = {
+  key: string;
+  milliseconds_timestamp: bigint;
+};
+
+export const _pexpireat: ResolverFunction<PExpireAtArg> = async (
+  root,
+  { key, milliseconds_timestamp },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.send_command(
+      "pexpireat",
+      key,
+      BigInt(milliseconds_timestamp)
+    );
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Set the expiration for a key as a UNIX timestamp specified in milliseconds.
+    [Read more >>](https://redis.io/commands/pexpireat)
+    """
+    _pexpireat(key: String!, milliseconds_timestamp: BigInt!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/pttl.ts
+++ b/graphql-server/src/scopes/commands/keys/pttl.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type PTTLArg = {
+  key: string;
+};
+
+export const _pttl: ResolverFunction<PTTLArg> = async (
+  root,
+  { key },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.pttl(key);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Get the time to live for a key in milliseconds. [Read more >>](https://redis.io/commands/pttl)
+    """
+    _pttl(key: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/randomkey.ts
+++ b/graphql-server/src/scopes/commands/keys/randomkey.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type RandomKeyArg = {
+  pattern: string;
+};
+
+export const _randomkey: ResolverFunction<any> = async (
+  root,
+  { pattern },
+  ctx
+): Promise<string> => {
+  try {
+    const reply = await redisClient.randomkey();
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Return a random key from the keyspace. [Read more >>](https://redis.io/commands/randomkey)
+    """
+    _randomkey: String
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/rename.ts
+++ b/graphql-server/src/scopes/commands/keys/rename.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type RenameArg = {
+  key: string;
+  newkey: string;
+};
+
+export const _rename: ResolverFunction<RenameArg> = async (
+  root,
+  { key, newkey },
+  ctx
+): Promise<string> => {
+  try {
+    const reply = await redisClient.rename(key, newkey);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Rename a key. [Read more >>](https://redis.io/commands/rename)
+    """
+    _rename(key: String!, newkey: String!): String
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/renamenx.ts
+++ b/graphql-server/src/scopes/commands/keys/renamenx.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type RenameNXArg = {
+  key: string;
+  newkey: string;
+};
+
+export const _renamenx: ResolverFunction<RenameNXArg> = async (
+  root,
+  { key, newkey },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.renamenx(key, newkey);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Rename a key, only if the new key does not exist. [Read more >>](https://redis.io/commands/renamenx)
+    """
+    _renamenx(key: String!, newkey: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/restore.ts
+++ b/graphql-server/src/scopes/commands/keys/restore.ts
@@ -1,0 +1,56 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type RestoreArg = {
+  key: string;
+  ttl: number;
+  serialized_value: string;
+  replace?: boolean;
+  absttl?: boolean;
+  idletime?: number;
+  freq?: number;
+};
+
+export const _restore: ResolverFunction<RestoreArg> = async (
+  root,
+  { key, ttl, serialized_value, replace, absttl, idletime, freq },
+  ctx
+): Promise<string> => {
+  try {
+    const args = [key, ttl, Buffer.from(serialized_value, "binary")];
+    if (replace === true) args.push("REPLACE");
+    if (absttl === true) args.push("ABSTTL");
+
+    if (typeof idletime !== "undefined") {
+      args.push("IDLETIME", idletime);
+    }
+
+    if (typeof freq !== "undefined") {
+      args.push("FREQ", freq);
+    }
+
+    const reply = await redisClient.restore(...args);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Create a key using the provided serialized value, previously obtained using DUMP.
+    [Read more >>](https://redis.io/commands/restore)
+    """
+    _restore(
+      key: String!
+      ttl: Int!
+      serialized_value: String!
+      replace: Boolean
+      absttl: Boolean
+      idletime: Int
+      freq: Int
+    ): String
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/scan.ts
+++ b/graphql-server/src/scopes/commands/keys/scan.ts
@@ -1,0 +1,101 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+import { KeyType } from "./type";
+
+export type ScanArg = {
+  cursor: number;
+  match?: string;
+  count?: number;
+  type: KeyType;
+};
+
+export type ScanResult = {
+  cursor: number;
+  keys: string[];
+  _prevArgs: ScanArg;
+  _next?: ScanResult;
+};
+
+export const typeResolvers = {
+  RedisScanResult: {
+    async _next({ cursor, _prevArgs }: ScanResult): Promise<ScanResult> {
+      const buildScanArg = (cursor: number) => {
+        const args: any[] = [cursor];
+        if (_prevArgs.match) args.push("MATCH", _prevArgs.match);
+        if (_prevArgs.count) args.push("COUNT", _prevArgs.count);
+        if (_prevArgs.type) args.push("TYPE", _prevArgs.type);
+        return args;
+      };
+
+      const [cursorResult, keysResult] = await redisClient.send_command(
+        "scan",
+        ...buildScanArg(cursor)
+      );
+
+      const scanResult: ScanResult = {
+        cursor: cursorResult,
+        keys: keysResult,
+        _prevArgs: {
+          cursor: _prevArgs.cursor,
+          type: _prevArgs.type,
+          count: _prevArgs.count,
+          match: _prevArgs.match
+        }
+      };
+
+      return scanResult;
+    }
+  }
+};
+
+export const _scan: ResolverFunction<ScanArg> = async (
+  root,
+  { cursor, type, count, match },
+  ctx
+): Promise<ScanResult> => {
+  try {
+    const buildScanArg = (cursor: number) => {
+      const args: any[] = [cursor];
+      if (match) args.push("MATCH", match);
+      if (count) args.push("COUNT", count);
+      if (type) args.push("TYPE", type);
+      return args;
+    };
+
+    const mainArgs = buildScanArg(cursor);
+    const [cursorResult, keysResult] = await redisClient.send_command(
+      "scan",
+      ...mainArgs
+    );
+
+    const scanResult: ScanResult = {
+      cursor: cursorResult,
+      keys: keysResult,
+      _prevArgs: { cursor, type, count, match }
+    };
+    return scanResult;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  type RedisScanResult {
+    cursor: Int
+    keys: [String]
+    _next: RedisScanResult
+  }
+
+  extend type Query {
+    """
+    Incrementally iterate the keys space. [Read more >>](https://redis.io/commands/scan)
+    """
+    _scan(
+      cursor: Int!
+      match: String
+      count: Int
+      type: KeyType
+    ): RedisScanResult
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/touch.ts
+++ b/graphql-server/src/scopes/commands/keys/touch.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type TouchArg = {
+  keys: string[];
+};
+
+export const _touch: ResolverFunction<TouchArg> = async (
+  root,
+  { keys },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.send_command("touch", ...keys);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Alters the last access time of a key(s). Returns the number of existing keys specified..
+    [Read more >>](https://redis.io/commands/touch)
+    """
+    _touch(keys: [String!]!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/ttl.ts
+++ b/graphql-server/src/scopes/commands/keys/ttl.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type TTLArg = {
+  key: string;
+};
+
+export const _ttl: ResolverFunction<TTLArg> = async (
+  root,
+  { key },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.ttl(key);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Get the time to live for a key. [Read more >>](https://redis.io/commands/ttl)
+    """
+    _ttl(key: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/type.ts
+++ b/graphql-server/src/scopes/commands/keys/type.ts
@@ -1,0 +1,47 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export enum KeyType {
+  string = "string",
+  list = "list",
+  set = "set",
+  zset = "zset",
+  hash = "hash",
+  stream = "stream"
+}
+
+export type TypeArg = {
+  key: string;
+};
+
+export const _type: ResolverFunction<TypeArg> = async (
+  root,
+  { key },
+  ctx
+): Promise<KeyType> => {
+  try {
+    const reply = await redisClient.type(key);
+    return reply as KeyType;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  enum KeyType {
+    string
+    list
+    set
+    zset
+    hash
+    stream
+  }
+
+  extend type Query {
+    """
+    Determine the type stored at key. [Read more >>](https://redis.io/commands/type)
+    """
+    _type(key: String!): KeyType
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/unlink.ts
+++ b/graphql-server/src/scopes/commands/keys/unlink.ts
@@ -1,0 +1,25 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type UnlinkArg = {
+  keys: string[];
+};
+
+export const _unlink: ResolverFunction<UnlinkArg> = async (
+  root,
+  { keys },
+  ctx
+): Promise<IntResp> => {
+  const reply = await redisClient.unlink(...keys);
+  return reply;
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Delete a key asynchronously in another thread. Otherwise it is just as DEL, but non blocking. [Read more >>](https://redis.io/commands/unlink)
+    """
+    _unlink(keys: [String!]!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/keys/wait.ts
+++ b/graphql-server/src/scopes/commands/keys/wait.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type WaitArg = {
+  numreplicas: number;
+  timeout: number;
+};
+
+export const _wait: ResolverFunction<WaitArg> = async (
+  root,
+  { numreplicas, timeout },
+  ctx
+): Promise<IntResp> => {
+  const reply = await redisClient.send_command(
+    "wait",
+    ...[numreplicas, timeout]
+  );
+  return reply;
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Wait for the synchronous replication of all the write commands sent in the context of the current connection. [Read more >>](https://redis.io/commands/wait)
+    """
+    _wait(numreplicas: Int!, timeout: Int!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/strings/append.ts
+++ b/graphql-server/src/scopes/commands/strings/append.ts
@@ -19,7 +19,7 @@ export const _append: ResolverFunction<AppendArg> = async (
 export const typeDefs = gql`
   extend type Mutation {
     """
-    Append a value to a key. [See more >>](https://redis.io/commands/append)
+    Append a value to a key. [Read more >>](https://redis.io/commands/append)
     """
     _append(key: String!, value: String!): Int
   }

--- a/graphql-server/src/scopes/commands/strings/bitcount.ts
+++ b/graphql-server/src/scopes/commands/strings/bitcount.ts
@@ -28,7 +28,7 @@ export const _bitcount: ResolverFunction<BitCountArgs> = async (
 export const typeDefs = gql`
   extend type Query {
     """
-    Count set bits in a string. [See more >>](https://redis.io/commands/bitcount)
+    Count set bits in a string. [Read more >>](https://redis.io/commands/bitcount)
     """
     _bitcount(key: String!, start: Int, end: Int): Int
   }

--- a/graphql-server/src/scopes/commands/strings/bitfield.ts
+++ b/graphql-server/src/scopes/commands/strings/bitfield.ts
@@ -316,7 +316,7 @@ export const typeDefs = gql`
 
   extend type Mutation {
     """
-    Perform arbitrary bitfield integer operations on strings. [See more >>](https://redis.io/commands/bitfield)
+    Perform arbitrary bitfield integer operations on strings. [Read more >>](https://redis.io/commands/bitfield)
     """
     _bitfield(key: String!, args: [BitFieldArgs]): [Int]
   }

--- a/graphql-server/src/scopes/commands/strings/bitop.ts
+++ b/graphql-server/src/scopes/commands/strings/bitop.ts
@@ -43,7 +43,7 @@ export const typeDefs = gql`
 
   extend type Mutation {
     """
-    Perform bitwise operations between strings. [See more >>](https://redis.io/commands/bitop)
+    Perform bitwise operations between strings. [Read more >>](https://redis.io/commands/bitop)
     """
     _bitop(operation: BitOperation!, destkey: String!, keys: [String!]!): Int
   }

--- a/graphql-server/src/scopes/commands/strings/bitpos.ts
+++ b/graphql-server/src/scopes/commands/strings/bitpos.ts
@@ -31,7 +31,7 @@ export const _bitpos: ResolverFunction<BitPosArgs> = async (
 export const typeDefs = gql`
   extend type Query {
     """
-    Find first bit set or clear in a string. [See more >>](https://redis.io/commands/bitpos)
+    Find first bit set or clear in a string. [Read more >>](https://redis.io/commands/bitpos)
     """
     _bitpos(key: String!, bit: Int!, start: Int, end: Int): Int
   }

--- a/graphql-server/src/scopes/commands/strings/decr.ts
+++ b/graphql-server/src/scopes/commands/strings/decr.ts
@@ -22,7 +22,7 @@ export const _decr: ResolverFunction<DecrArg> = async (
 export const typeDefs = gql`
   extend type Mutation {
     """
-    Decrement the integer value of a key by one. [See more >>](https://redis.io/commands/decr)
+    Decrement the integer value of a key by one. [Read more >>](https://redis.io/commands/decr)
     """
     _decr(key: String!): Int
   }

--- a/graphql-server/src/scopes/commands/strings/decrby.ts
+++ b/graphql-server/src/scopes/commands/strings/decrby.ts
@@ -23,7 +23,7 @@ export const _decrby: ResolverFunction<DecrByArg> = async (
 export const typeDefs = gql`
   extend type Mutation {
     """
-    Decrement the integer value of a key by the given number. [See more >>](https://redis.io/commands/decrby)
+    Decrement the integer value of a key by the given number. [Read more >>](https://redis.io/commands/decrby)
     """
     _decrby(key: String!, decrement: Int!): Int
   }

--- a/graphql-server/src/scopes/commands/strings/get.ts
+++ b/graphql-server/src/scopes/commands/strings/get.ts
@@ -18,7 +18,7 @@ export const _get: ResolverFunction<GetArg> = async (
 export const typeDefs = gql`
   extend type Query {
     """
-    Get the value of key. [See more >>](https://redis.io/commands/get)
+    Get the value of key. [Read more >>](https://redis.io/commands/get)
     """
     _get(key: String!): String
   }

--- a/graphql-server/src/scopes/commands/strings/getbit.ts
+++ b/graphql-server/src/scopes/commands/strings/getbit.ts
@@ -23,7 +23,7 @@ export const _getbit: ResolverFunction<GetBitArg> = async (
 export const typeDefs = gql`
   extend type Query {
     """
-    Returns the bit value at offset in the string value stored at key. [See more >>](https://redis.io/commands/getbit)
+    Returns the bit value at offset in the string value stored at key. [Read more >>](https://redis.io/commands/getbit)
     """
     _getbit(key: String!, offset: Int!): Int
   }

--- a/graphql-server/src/scopes/commands/strings/getrange.ts
+++ b/graphql-server/src/scopes/commands/strings/getrange.ts
@@ -24,7 +24,7 @@ export const _getrange: ResolverFunction<GetRangeArg> = async (
 export const typeDefs = gql`
   extend type Query {
     """
-    Get a substring of the string stored at a key. [See more >>](https://redis.io/commands/getrange)
+    Get a substring of the string stored at a key. [Read more >>](https://redis.io/commands/getrange)
     """
     _getrange(key: String!, start: Int!, end: Int!): RespBulk
   }

--- a/graphql-server/src/scopes/commands/strings/getset.ts
+++ b/graphql-server/src/scopes/commands/strings/getset.ts
@@ -19,7 +19,7 @@ export const _getset: ResolverFunction<GetSetArg> = async (
 export const typeDefs = gql`
   extend type Mutation {
     """
-    Set the string value of a key and return its old value. [See more >>](https://redis.io/commands/getset)
+    Set the string value of a key and return its old value. [Read more >>](https://redis.io/commands/getset)
     """
     _getset(key: String!, value: String!): RespBulk
   }

--- a/graphql-server/src/scopes/commands/strings/incr.ts
+++ b/graphql-server/src/scopes/commands/strings/incr.ts
@@ -22,7 +22,7 @@ export const _incr: ResolverFunction<IncrArg> = async (
 export const typeDefs = gql`
   extend type Mutation {
     """
-    Increment the integer value of a key by one. [See more >>](https://redis.io/commands/incr)
+    Increment the integer value of a key by one. [Read more >>](https://redis.io/commands/incr)
     """
     _incr(key: String!): Int
   }

--- a/graphql-server/src/scopes/commands/strings/incrby.ts
+++ b/graphql-server/src/scopes/commands/strings/incrby.ts
@@ -23,7 +23,7 @@ export const _incrby: ResolverFunction<IncrByArg> = async (
 export const typeDefs = gql`
   extend type Mutation {
     """
-    Increment the integer value of a key by the given amount. [See more >>](https://redis.io/commands/incrby)
+    Increment the integer value of a key by the given amount. [Read more >>](https://redis.io/commands/incrby)
     """
     _incrby(key: String!, increment: Int!): Int
   }

--- a/graphql-server/src/scopes/commands/strings/incrbyfloat.ts
+++ b/graphql-server/src/scopes/commands/strings/incrbyfloat.ts
@@ -23,7 +23,7 @@ export const _incrbyfloat: ResolverFunction<IncrByFloatArg> = async (
 export const typeDefs = gql`
   extend type Mutation {
     """
-    Increment the float value of a key by the given amount. [See more >>](https://redis.io/commands/incrbyfloat)
+    Increment the float value of a key by the given amount. [Read more >>](https://redis.io/commands/incrbyfloat)
     """
     _incrbyfloat(key: String!, increment: Float!): RespBulk
   }

--- a/graphql-server/src/scopes/commands/strings/mget.ts
+++ b/graphql-server/src/scopes/commands/strings/mget.ts
@@ -31,7 +31,7 @@ export const _mget: ResolverFunction<MGetArgs> = async (
 export const typeDefs = gql`
   extend type Query {
     """
-    Get the values of all the given keys. [See more >>](https://redis.io/commands/mget)
+    Get the values of all the given keys. [Read more >>](https://redis.io/commands/mget)
     """
     _mget(keys: [String!]!): JSON
   }

--- a/graphql-server/src/scopes/commands/strings/mset.ts
+++ b/graphql-server/src/scopes/commands/strings/mset.ts
@@ -3,18 +3,20 @@ import { ResolverFunction, OKResp, OK, KeyValue } from "@typings";
 import { redisClient } from "@adapters/redis";
 
 export type MSetArg = {
-  args: KeyValue[];
+  data: any[];
 };
 
 export const _mset: ResolverFunction<MSetArg> = async (
   root,
-  { args: keyValues },
+  { data },
   ctx
 ): Promise<OKResp> => {
   try {
-    const msetArgs = keyValues.map(({ key, value }) => [key, value]).flat();
+    const msetArgs = Object.keys(data)
+      .map(key => [key, data[key]])
+      .flat();
     const reply = await redisClient.mset.apply(redisClient, msetArgs);
-    return OK;
+    return reply;
   } catch (err) {
     console.error(err);
     return null;
@@ -29,8 +31,8 @@ export const typeDefs = gql`
 
   extend type Mutation {
     """
-    Set multiple keys to multiple values. [See more >>](https://redis.io/commands/mset)
+    Set multiple keys to multiple values. [Read more >>](https://redis.io/commands/mset)
     """
-    _mset(args: [KeyValues!]!): OK
+    _mset(data: JSON!): OK
   }
 `;

--- a/graphql-server/src/scopes/commands/strings/msetnx.ts
+++ b/graphql-server/src/scopes/commands/strings/msetnx.ts
@@ -22,7 +22,7 @@ export const _msetnx: ResolverFunction<MSetNXArg> = async (
 export const typeDefs = gql`
   extend type Mutation {
     """
-    Set multiple keys to multiple values, only if none of the keys exist. [See more >>](https://redis.io/commands/msetnx)
+    Set multiple keys to multiple values, only if none of the keys exist. [Read more >>](https://redis.io/commands/msetnx)
     """
     _msetnx(data: JSON!): Int
   }

--- a/graphql-server/src/scopes/commands/strings/psetex.ts
+++ b/graphql-server/src/scopes/commands/strings/psetex.ts
@@ -24,7 +24,7 @@ export const _psetex: ResolverFunction<PSetExArgs> = async (
 export const typeDefs = gql`
   extend type Mutation {
     """
-    Set the value and expiration in milliseconds of a key. [See more >>](https://redis.io/commands/psetex)
+    Set the value and expiration in milliseconds of a key. [Read more >>](https://redis.io/commands/psetex)
     """
     _psetex(key: String!, milliseconds: Int!, value: String!): String
   }

--- a/graphql-server/src/scopes/commands/strings/set.ts
+++ b/graphql-server/src/scopes/commands/strings/set.ts
@@ -52,7 +52,7 @@ export const typeDefs = gql`
 
   extend type Mutation {
     """
-    Set key to hold the string value. [See more >>](https://redis.io/commands/set)
+    Set key to hold the string value. [Read more >>](https://redis.io/commands/set)
     """
     _set(
       key: String!

--- a/graphql-server/src/scopes/commands/strings/setbit.ts
+++ b/graphql-server/src/scopes/commands/strings/setbit.ts
@@ -24,7 +24,7 @@ export const _setbit: ResolverFunction<SetBitArg> = async (
 export const typeDefs = gql`
   extend type Mutation {
     """
-    Sets or clears the bit at offset in the string value stored at key. [See more >>](https://redis.io/commands/setbit)
+    Sets or clears the bit at offset in the string value stored at key. [Read more >>](https://redis.io/commands/setbit)
     """
     _setbit(key: String!, offset: Int!, value: Int!): Int
   }

--- a/graphql-server/src/scopes/commands/strings/setex.ts
+++ b/graphql-server/src/scopes/commands/strings/setex.ts
@@ -24,7 +24,7 @@ export const _setex: ResolverFunction<SetExArgs> = async (
 export const typeDefs = gql`
   extend type Mutation {
     """
-    Set the value and expiration of a key. [See more >>](https://redis.io/commands/setex)
+    Set the value and expiration of a key. [Read more >>](https://redis.io/commands/setex)
     """
     _setex(key: String!, seconds: Int!, value: String!): String
   }

--- a/graphql-server/src/scopes/commands/strings/setnx.ts
+++ b/graphql-server/src/scopes/commands/strings/setnx.ts
@@ -23,7 +23,7 @@ export const _setnx: ResolverFunction<SetNXArg> = async (
 export const typeDefs = gql`
   extend type Mutation {
     """
-    Set the value of a key, only if the key does not exist. [See more >>](https://redis.io/commands/setnx)
+    Set the value of a key, only if the key does not exist. [Read more >>](https://redis.io/commands/setnx)
     """
     _setnx(key: String!, value: String!): Int
   }

--- a/graphql-server/src/scopes/commands/strings/setrange.ts
+++ b/graphql-server/src/scopes/commands/strings/setrange.ts
@@ -24,7 +24,7 @@ export const _setrange: ResolverFunction<SetRangeArg> = async (
 export const typeDefs = gql`
   extend type Mutation {
     """
-    Overwrite part of a string at key starting at the specified offset. [See more >>](https://redis.io/commands/setrange)
+    Overwrite part of a string at key starting at the specified offset. [Read more >>](https://redis.io/commands/setrange)
     """
     _setrange(key: String!, offset: Int!, value: String!): Int
   }

--- a/graphql-server/src/scopes/commands/strings/strlen.ts
+++ b/graphql-server/src/scopes/commands/strings/strlen.ts
@@ -18,7 +18,7 @@ export const _strlen: ResolverFunction<StrlenArg> = async (
 export const typeDefs = gql`
   extend type Query {
     """
-    Get the length of the value stored in a key. [See more >>](https://redis.io/commands/strlen)
+    Get the length of the value stored in a key. [Read more >>](https://redis.io/commands/strlen)
     """
     _strlen(key: String!): Int
   }

--- a/graphql-server/src/scopes/server/index.ts
+++ b/graphql-server/src/scopes/server/index.ts
@@ -1,10 +1,72 @@
 import gql from "graphql-tag";
 import _version from "./version";
 import { default as _test, typeDefs as testTypeDefs } from "./test";
-import GraphQLJSON from "graphql-type-json";
+import {
+  DateTimeResolver,
+  EmailAddressResolver,
+  NegativeFloatResolver,
+  NegativeIntResolver,
+  NonNegativeFloatResolver,
+  NonNegativeIntResolver,
+  NonPositiveFloatResolver,
+  NonPositiveIntResolver,
+  PhoneNumberResolver,
+  PositiveFloatResolver,
+  PositiveIntResolver,
+  PostalCodeResolver,
+  UnsignedFloatResolver,
+  UnsignedIntResolver,
+  URLResolver,
+  BigIntResolver,
+  LongResolver,
+  GUIDResolver,
+  HexColorCodeResolver,
+  HSLResolver,
+  HSLAResolver,
+  IPv4Resolver,
+  IPv6Resolver,
+  ISBNResolver,
+  MACResolver,
+  PortResolver,
+  RGBResolver,
+  RGBAResolver,
+  USCurrencyResolver,
+  JSONResolver,
+  JSONObjectResolver
+} from "graphql-scalars";
 
 const JSONTypedef = gql`
+  scalar BigInt
+  scalar DateTime
+  scalar EmailAddress
+  scalar GUID
+  scalar HexColorCode
+  scalar HSL
+  scalar HSLA
+  scalar IPv4
+  scalar IPv6
+  scalar ISBN
   scalar JSON
+  scalar JSONObject
+  scalar Long
+  scalar MAC
+  scalar NegativeFloat
+  scalar NegativeInt
+  scalar NonNegativeFloat
+  scalar NonNegativeInt
+  scalar NonPositiveFloat
+  scalar NonPositiveInt
+  scalar PhoneNumber
+  scalar Port
+  scalar PositiveFloat
+  scalar PositiveInt
+  scalar PostalCode
+  scalar RGB
+  scalar RGBA
+  scalar UnsignedFloat
+  scalar UnsignedInt
+  scalar URL
+  scalar USCurrency
 `;
 
 const rootTypeDefs = gql`
@@ -35,6 +97,36 @@ export const resolver = {
     _test
   },
   scalars: {
-    JSON: GraphQLJSON
+    DateTime: DateTimeResolver,
+    NonPositiveInt: NonPositiveIntResolver,
+    PositiveInt: PositiveIntResolver,
+    NonNegativeInt: NonNegativeIntResolver,
+    NegativeInt: NegativeIntResolver,
+    NonPositiveFloat: NonPositiveFloatResolver,
+    PositiveFloat: PositiveFloatResolver,
+    NonNegativeFloat: NonNegativeFloatResolver,
+    NegativeFloat: NegativeFloatResolver,
+    UnsignedFloat: UnsignedFloatResolver,
+    UnsignedInt: UnsignedIntResolver,
+    BigInt: BigIntResolver,
+    Long: LongResolver,
+    EmailAddress: EmailAddressResolver,
+    URL: URLResolver,
+    PhoneNumber: PhoneNumberResolver,
+    PostalCode: PostalCodeResolver,
+    GUID: GUIDResolver,
+    HexColorCode: HexColorCodeResolver,
+    HSL: HSLResolver,
+    HSLA: HSLAResolver,
+    RGB: RGBResolver,
+    RGBA: RGBAResolver,
+    IPv4: IPv4Resolver,
+    IPv6: IPv6Resolver,
+    MAC: MACResolver,
+    Port: PortResolver,
+    ISBN: ISBNResolver,
+    USCurrency: USCurrencyResolver,
+    JSON: JSONResolver,
+    JSONObject: JSONObjectResolver
   }
 };

--- a/graphql-server/tsconfig.json
+++ b/graphql-server/tsconfig.json
@@ -6,6 +6,7 @@
     "noImplicitAny": false,
     "baseUrl": "./src",
     "outDir": "./dist",
+    "downlevelIteration": true,
     "paths": {
       "@scopes/*": ["scopes/*"],
       "@adapters/*": ["adapters/*"],

--- a/graphql-server/yarn.lock
+++ b/graphql-server/yarn.lock
@@ -149,13 +149,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/graphql-type-json@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@types/graphql-type-json/-/graphql-type-json-0.3.2.tgz#1a7105e6546fc1630a5db4834bfbc0eb554986e4"
-  integrity sha512-c1cq4o8EhY0Z39ua8UXwG8uBs23xBYA/Uw0tXFl6SuTUpkVv/IJqf6pHQbfdC7nwFRhX2ifTOV/UIg0Q/IJsbg==
-  dependencies:
-    graphql "^14.5.3"
-
 "@types/graphql-type-uuid@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@types/graphql-type-uuid/-/graphql-type-uuid-0.2.3.tgz#4ba98c8e50fa44c60c1b5ee0bc2c0f0629afff0b"
@@ -247,6 +240,11 @@
   version "12.7.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.12.tgz#7c6c571cc2f3f3ac4a59a5f2bd48f5bdbc8653cc"
   integrity sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ==
+
+"@types/node@12.12.24":
+  version "12.12.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.24.tgz#d4606afd8cf6c609036b854360367d1b2c78931f"
+  integrity sha512-1Ciqv9pqwVtW6FsIUKSZNB82E5Cu1I2bBTj1xuIHXLe/1zYLl3956Nbhg2MzSYHVfl9/rmanjbQIb7LibfCnug==
 
 "@types/node@^10.1.0":
   version "10.17.14"
@@ -888,6 +886,13 @@ graphql-extensions@^0.10.10:
     apollo-server-env "^2.4.3"
     apollo-server-types "^0.2.10"
 
+graphql-scalars@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/graphql-scalars/-/graphql-scalars-1.0.6.tgz#7fd9bcc51116f9cebb03a27508d8e5b605675f92"
+  integrity sha512-HrXDZyC1dxp858TaNBNEDhUnwT5C4LwStZOXwSAQ+1h2Xl8aPrCy9M4ASu/ymBpo97sFAjSuNAJklfZedLABJg==
+  dependencies:
+    "@types/node" "12.12.24"
+
 graphql-subscriptions@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz#5f2fa4233eda44cf7570526adfcf3c16937aef11"
@@ -910,11 +915,6 @@ graphql-tools@^4.0.0:
     deprecated-decorator "^0.1.6"
     iterall "^1.1.3"
     uuid "^3.1.0"
-
-graphql-type-json@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.3.1.tgz#47fca2b1fa7adc0758d165b33580d7be7a6cf548"
-  integrity sha512-1lPkUXQ2L8o+ERLzVAuc3rzc/E6pGF+6HnjihCVTK0VzR0jCuUd92FqNxoHdfILXqOn2L6b4y47TBxiPyieUVA==
 
 graphql-type-uuid@^0.2.0:
   version "0.2.0"
@@ -1101,6 +1101,11 @@ iterall@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
+
+jsesc@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
+  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
 json5@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR adds redis keys command to GraphQL. Also

- Change text in description [See More] to Read More
- Add Custom Scalars with graphql-scalars
- Add Custom  types resolvers to typeDefs