### PR TITLE
graphql-server/feat: Add redis sets command to GraphQL

### DIFF
--- a/graphql-server/src/scopes/commands/index.ts
+++ b/graphql-server/src/scopes/commands/index.ts
@@ -12,6 +12,10 @@ import {
   resolvers as connectionsCommandResolver,
   typeDefs as connectionsTypeDefs
 } from "./connections";
+import {
+  resolvers as setsCommandResolver,
+  typeDefs as setsTypeDefs
+} from "./sets";
 
 const redisTypeDefs = gql`
   scalar OK
@@ -35,19 +39,22 @@ export const typeDefs = [
   redisTypeDefs,
   ...stringTypeDefs,
   ...keysTypeDefs,
-  ...connectionsTypeDefs
+  ...connectionsTypeDefs,
+  ...setsTypeDefs
 ];
 
 export const resolvers = {
   query: {
     ...stringCommandResolvers.query,
     ...keysCommandResolver.query,
-    ...connectionsCommandResolver.query
+    ...connectionsCommandResolver.query,
+    ...setsCommandResolver.query
   },
   mutation: {
     ...stringCommandResolvers.mutation,
     ...keysCommandResolver.mutation,
-    ...connectionsCommandResolver.mutation
+    ...connectionsCommandResolver.mutation,
+    ...setsCommandResolver.mutation
   },
   subscription: {},
   types: {

--- a/graphql-server/src/scopes/commands/sets/index.ts
+++ b/graphql-server/src/scopes/commands/sets/index.ts
@@ -1,0 +1,57 @@
+import { typeDefs as saddTypeDefs, _sadd } from "./sadd";
+import { typeDefs as scardTypeDefs, _scard } from "./scard";
+import { typeDefs as sdiffTypeDefs, _sdiff } from "./sdiff";
+import { typeDefs as sdiffStoreTypeDefs, _sdiffstore } from "./sdiffstore";
+import { typeDefs as sinterTypeDefs, _sinter } from "./sinter";
+import { typeDefs as sinterStoreTypeDefs, _sinterstore } from "./sinterstore";
+import { typeDefs as sisMemberTypeDefs, _sismember } from "./sismember";
+import { typeDefs as sMembersTypeDefs, _smembers } from "./smembers";
+import { typeDefs as sMoveTypeDefs, _smove } from "./smove";
+import { typeDefs as spopTypeDefs, _spop } from "./spop";
+import { typeDefs as srandMemberTypeDefs, _srandmember } from "./srandmember";
+import { typeDefs as sremTypeDefs, _srem } from "./srem";
+import { typeDefs as sunionTypeDefs, _sunion } from "./sunion";
+import { typeDefs as sunionStoreTypeDefs, _sunionstore } from "./sunionstore";
+import { typeDefs as sscanTypeDefs, _sscan } from "./sscan";
+
+export const typeDefs = [
+  saddTypeDefs,
+  scardTypeDefs,
+  sdiffTypeDefs,
+  sdiffStoreTypeDefs,
+  sinterTypeDefs,
+  sinterStoreTypeDefs,
+  sisMemberTypeDefs,
+  sMembersTypeDefs,
+  sMoveTypeDefs,
+  spopTypeDefs,
+  srandMemberTypeDefs,
+  sremTypeDefs,
+  sunionTypeDefs,
+  sunionStoreTypeDefs,
+  sscanTypeDefs
+];
+
+export const resolvers = {
+  query: {
+    _scard,
+    _sdiff,
+    _sinter,
+    _sismember,
+    _smembers,
+    _srandmember,
+    _sunion,
+    _sscan
+  },
+  mutation: {
+    _sadd,
+    _sdiffstore,
+    _sinterstore,
+    _sunionstore,
+    _smove,
+    _spop,
+    _srem
+  },
+  subscription: {},
+  types: {}
+};

--- a/graphql-server/src/scopes/commands/sets/sadd.ts
+++ b/graphql-server/src/scopes/commands/sets/sadd.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type SAddArg = {
+  key: string;
+  members: string[];
+};
+
+export const _sadd: ResolverFunction<SAddArg> = async (
+  root,
+  { key, members },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.sadd(key, ...members);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Add one or more members to a set. [Read more >>](https://redis.io/commands/sadd)
+    """
+    _sadd(key: String!, members: [String!]!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sets/scard.ts
+++ b/graphql-server/src/scopes/commands/sets/scard.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type SCardArg = {
+  key: string;
+};
+
+export const _scard: ResolverFunction<SCardArg> = async (
+  root,
+  { key },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.scard(key);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Get the number of members in a set. [Read more >>](https://redis.io/commands/scard)
+    """
+    _scard(key: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sets/sdiff.ts
+++ b/graphql-server/src/scopes/commands/sets/sdiff.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type SDiffArg = {
+  keys: [string];
+};
+
+export const _sdiff: ResolverFunction<SDiffArg> = async (
+  root,
+  { keys },
+  ctx
+): Promise<string[]> => {
+  try {
+    const reply = await redisClient.sdiff(...keys);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Subtract multiple sets. [Read more >>](https://redis.io/commands/sdiff)
+    """
+    _sdiff(keys: [String]!): [String]
+  }
+`;

--- a/graphql-server/src/scopes/commands/sets/sdiffstore.ts
+++ b/graphql-server/src/scopes/commands/sets/sdiffstore.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type SDiffStoreArg = {
+  destination: string;
+  keys: [string];
+};
+
+export const _sdiffstore: ResolverFunction<SDiffStoreArg> = async (
+  root,
+  { destination, keys },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.sdiffstore(destination, ...keys);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Subtract multiple sets and store the resulting set in a key. [Read more >>](https://redis.io/commands/sdiffstore)
+    """
+    _sdiffstore(destination: String!, keys: [String]!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sets/sinter.ts
+++ b/graphql-server/src/scopes/commands/sets/sinter.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type SInterArg = {
+  keys: [string];
+};
+
+export const _sinter: ResolverFunction<SInterArg> = async (
+  root,
+  { keys },
+  ctx
+): Promise<string[]> => {
+  try {
+    const reply = await redisClient.sinter(...keys);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Intersect multiple sets. [Read more >>](https://redis.io/commands/sinter)
+    """
+    _sinter(keys: [String]!): [String]
+  }
+`;

--- a/graphql-server/src/scopes/commands/sets/sinterstore.ts
+++ b/graphql-server/src/scopes/commands/sets/sinterstore.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type SInterStoreArg = {
+  destination: string;
+  keys: [string];
+};
+
+export const _sinterstore: ResolverFunction<SInterStoreArg> = async (
+  root,
+  { destination, keys },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.sinterstore(destination, ...keys);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Intersect multiple sets and store the resulting set in a key. [Read more >>](https://redis.io/commands/sinterstore)
+    """
+    _sinterstore(destination: String!, keys: [String]!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sets/sismember.ts
+++ b/graphql-server/src/scopes/commands/sets/sismember.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type SIsMemberArg = {
+  key: string;
+  member: string;
+};
+
+export const _sismember: ResolverFunction<SIsMemberArg> = async (
+  root,
+  { key, member },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.sismember(key, member);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Determine if a given value is a member of a set. [Read more >>](https://redis.io/commands/sismember)
+    """
+    _sismember(key: String!, member: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sets/smembers.ts
+++ b/graphql-server/src/scopes/commands/sets/smembers.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type SMembersArg = {
+  key: string;
+};
+
+export const _smembers: ResolverFunction<SMembersArg> = async (
+  root,
+  { key },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.smembers(key);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Get all the members in a set. [Read more >>](https://redis.io/commands/smembers)
+    """
+    _smembers(key: String!): [String]
+  }
+`;

--- a/graphql-server/src/scopes/commands/sets/smove.ts
+++ b/graphql-server/src/scopes/commands/sets/smove.ts
@@ -1,0 +1,31 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type SMoveArg = {
+  source: string;
+  destination: string;
+  member: string;
+};
+
+export const _smove: ResolverFunction<SMoveArg> = async (
+  root,
+  { source, destination, member },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.smove(source, destination, member);
+    return parseInt(reply, 10);
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Move a member from one set to another. [Read more >>](https://redis.io/commands/smove)
+    """
+    _smove(source: String!, destination: String!, member: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sets/spop.ts
+++ b/graphql-server/src/scopes/commands/sets/spop.ts
@@ -1,0 +1,32 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type SPopArg = {
+  key: string;
+  count?: number;
+};
+
+export const _spop: ResolverFunction<SPopArg> = async (
+  root,
+  { key, count },
+  ctx
+): Promise<string> => {
+  try {
+    const reply = count
+      ? await redisClient.spop(key, count)
+      : redisClient.spop(key);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Remove and return one or multiple random members from a set. [Read more >>](https://redis.io/commands/spop)
+    """
+    _spop(key: String!, count: Int): String
+  }
+`;

--- a/graphql-server/src/scopes/commands/sets/srandmember.ts
+++ b/graphql-server/src/scopes/commands/sets/srandmember.ts
@@ -1,0 +1,32 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type SRandMemberArg = {
+  key: string;
+  count?: number;
+};
+
+export const _srandmember: ResolverFunction<SRandMemberArg> = async (
+  root,
+  { key, count },
+  ctx
+): Promise<string | string[]> => {
+  try {
+    const reply = count
+      ? await redisClient.srandmember(key, count)
+      : await redisClient.srandmember(key);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Get one or multiple random members from a set. [Read more >>](https://redis.io/commands/srandmember)
+    """
+    _srandmember(key: String!, count: Int): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/sets/srem.ts
+++ b/graphql-server/src/scopes/commands/sets/srem.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type SRemArg = {
+  key: string;
+  members: string[];
+};
+
+export const _srem: ResolverFunction<SRemArg> = async (
+  root,
+  { key, members },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.srem(key, ...members);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Remove one or more members from a set. [Read more >>](https://redis.io/commands/srem)
+    """
+    _srem(key: String!, members: [String]): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sets/sscan.ts
+++ b/graphql-server/src/scopes/commands/sets/sscan.ts
@@ -1,0 +1,45 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+import { ScanArg, ScanResult, doScan, ScanType } from "../keys/scan";
+
+export type SScanArg = { key: string } & ScanArg;
+
+export const typeResolvers = {
+  RedisSScanResult: {
+    _next: async (args: ScanResult): Promise<ScanResult> => {
+      return await doScan({
+        scanCommand: ScanType.SSCAN,
+        args,
+        prevArgs: args._prevArgs
+      });
+    }
+  }
+};
+
+export const _sscan: ResolverFunction<SScanArg> = async (
+  root,
+  args,
+  ctx
+): Promise<ScanResult> => {
+  try {
+    return await doScan({ scanCommand: ScanType.SSCAN, args });
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Incrementally iterate the keys space. [Read more >>](https://redis.io/commands/scan)
+    """
+    _sscan(
+      key: String!
+      cursor: Int!
+      match: String
+      count: Int
+      type: KeyType
+    ): RedisScanResult
+  }
+`;

--- a/graphql-server/src/scopes/commands/sets/sunion.ts
+++ b/graphql-server/src/scopes/commands/sets/sunion.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type SUnionArg = {
+  keys: string[];
+};
+
+export const _sunion: ResolverFunction<SUnionArg> = async (
+  root,
+  { keys },
+  ctx
+): Promise<string[]> => {
+  try {
+    const reply = await redisClient.sunion(...keys);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Add multiple sets. [Read more >>](https://redis.io/commands/sunion)
+    """
+    _sunion(keys: [String!]!): [String]
+  }
+`;

--- a/graphql-server/src/scopes/commands/sets/sunionstore.ts
+++ b/graphql-server/src/scopes/commands/sets/sunionstore.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type SUnionStoreArg = {
+  destination: string;
+  keys: string[];
+};
+
+export const _sunionstore: ResolverFunction<SUnionStoreArg> = async (
+  root,
+  { destination, keys },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.sunionstore(destination, ...keys);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Add multiple sets and store the resulting set in a key. [Read more >>](https://redis.io/commands/sunionstore)
+    """
+    _sunionstore(destination: String, keys: [String!]!): Int
+  }
+`;


### PR DESCRIPTION
This PR adds Redis set commands to GraphQL. Also, make scan function reusable for other types of SCAN; SSCAN, HSCAN, ZSCAN.