### PR TITLE
graphql-server/feat: Schema Stitching

### DIFF
--- a/graphql-server/src/app.ts
+++ b/graphql-server/src/app.ts
@@ -1,34 +1,14 @@
-import { ApolloServer, IResolvers } from "apollo-server";
+import { ApolloServer, IResolvers, mergeSchemas } from "apollo-server";
 import listenHandler from "./handlers/listen";
-import {
-  typeDefs as rootTypeDefs,
-  resolver as rootResolver
-} from "./scopes/server";
+import { schema as serverSchema } from "./scopes/server";
+import { schema as redisCommandSchema } from "./scopes/commands";
 
-import {
-  resolvers as redisCommandResolvers,
-  typeDefs as redisCommandTypeDefs
-} from "./scopes/commands";
-
-const resolvers: IResolvers = {
-  Query: {
-    ...rootResolver.query,
-    ...redisCommandResolvers.query
-  },
-
-  Mutation: {
-    ...rootResolver.mutation,
-    ...redisCommandResolvers.mutation
-  },
-
-  ...rootResolver.scalars,
-  ...redisCommandResolvers.types,
-  ...redisCommandResolvers.custom
-};
+const mergedSchema = mergeSchemas({
+  schemas: [redisCommandSchema, serverSchema]
+});
 
 const serverOptions = {
-  typeDefs: [...rootTypeDefs, ...redisCommandTypeDefs],
-  resolvers
+  schema: mergedSchema
 };
 
 const server = new ApolloServer(serverOptions);

--- a/graphql-server/src/scopes/commands/index.ts
+++ b/graphql-server/src/scopes/commands/index.ts
@@ -1,6 +1,10 @@
 import gql from "graphql-tag";
 import { OKScalar, RespBulkScalar, IntStringScalarType } from "./scalars";
 import {
+  resolvers as customScalarResolvers,
+  typeDefs as customScalarTypeDefs
+} from "@scopes/scalars";
+import {
   resolvers as stringCommandResolvers,
   typeDefs as stringTypeDefs
 } from "./strings";
@@ -16,6 +20,7 @@ import {
   resolvers as setsCommandResolver,
   typeDefs as setsTypeDefs
 } from "./sets";
+import { makeExecutableSchema } from "apollo-server";
 
 const redisTypeDefs = gql`
   scalar OK
@@ -27,15 +32,29 @@ const redisTypeDefs = gql`
     key: String
     value: String
   }
+
+  type Query {
+    _version: String
+  }
+
+  type Mutation {
+    _echo: String
+  }
+
+  type Subscription {
+    _test: String
+  }
 `;
 
 const customScalarResolver = {
   OK: OKScalar,
   RespBulk: RespBulkScalar,
-  IntString: IntStringScalarType
+  IntString: IntStringScalarType,
+  ...customScalarResolvers
 };
 
 export const typeDefs = [
+  customScalarTypeDefs,
   redisTypeDefs,
   ...stringTypeDefs,
   ...keysTypeDefs,
@@ -44,21 +63,21 @@ export const typeDefs = [
 ];
 
 export const resolvers = {
-  query: {
+  Query: {
     ...stringCommandResolvers.query,
     ...keysCommandResolver.query,
     ...connectionsCommandResolver.query,
     ...setsCommandResolver.query
   },
-  mutation: {
+  Mutation: {
     ...stringCommandResolvers.mutation,
     ...keysCommandResolver.mutation,
     ...connectionsCommandResolver.mutation,
     ...setsCommandResolver.mutation
   },
-  subscription: {},
-  types: {
-    ...keysCommandResolver.types
-  },
-  custom: { ...customScalarResolver }
+  Subscription: {},
+  ...keysCommandResolver.types,
+  ...customScalarResolver
 };
+
+export const schema = makeExecutableSchema({ typeDefs, resolvers });

--- a/graphql-server/src/scopes/scalars/index.ts
+++ b/graphql-server/src/scopes/scalars/index.ts
@@ -1,0 +1,102 @@
+import {
+  DateTimeResolver,
+  EmailAddressResolver,
+  NegativeFloatResolver,
+  NegativeIntResolver,
+  NonNegativeFloatResolver,
+  NonNegativeIntResolver,
+  NonPositiveFloatResolver,
+  NonPositiveIntResolver,
+  PhoneNumberResolver,
+  PositiveFloatResolver,
+  PositiveIntResolver,
+  PostalCodeResolver,
+  UnsignedFloatResolver,
+  UnsignedIntResolver,
+  URLResolver,
+  BigIntResolver,
+  LongResolver,
+  GUIDResolver,
+  HexColorCodeResolver,
+  HSLResolver,
+  HSLAResolver,
+  IPv4Resolver,
+  IPv6Resolver,
+  ISBNResolver,
+  MACResolver,
+  PortResolver,
+  RGBResolver,
+  RGBAResolver,
+  USCurrencyResolver,
+  JSONResolver,
+  JSONObjectResolver
+} from "graphql-scalars";
+import gql from 'graphql-tag';
+
+export const typeDefs = gql`
+  scalar BigInt
+  scalar DateTime
+  scalar EmailAddress
+  scalar GUID
+  scalar HexColorCode
+  scalar HSL
+  scalar HSLA
+  scalar IPv4
+  scalar IPv6
+  scalar ISBN
+  scalar JSON
+  scalar JSONObject
+  scalar Long
+  scalar MAC
+  scalar NegativeFloat
+  scalar NegativeInt
+  scalar NonNegativeFloat
+  scalar NonNegativeInt
+  scalar NonPositiveFloat
+  scalar NonPositiveInt
+  scalar PhoneNumber
+  scalar Port
+  scalar PositiveFloat
+  scalar PositiveInt
+  scalar PostalCode
+  scalar RGB
+  scalar RGBA
+  scalar UnsignedFloat
+  scalar UnsignedInt
+  scalar URL
+  scalar USCurrency
+`;
+
+export const resolvers = {
+  DateTime: DateTimeResolver,
+  NonPositiveInt: NonPositiveIntResolver,
+  PositiveInt: PositiveIntResolver,
+  NonNegativeInt: NonNegativeIntResolver,
+  NegativeInt: NegativeIntResolver,
+  NonPositiveFloat: NonPositiveFloatResolver,
+  PositiveFloat: PositiveFloatResolver,
+  NonNegativeFloat: NonNegativeFloatResolver,
+  NegativeFloat: NegativeFloatResolver,
+  UnsignedFloat: UnsignedFloatResolver,
+  UnsignedInt: UnsignedIntResolver,
+  BigInt: BigIntResolver,
+  Long: LongResolver,
+  EmailAddress: EmailAddressResolver,
+  URL: URLResolver,
+  PhoneNumber: PhoneNumberResolver,
+  PostalCode: PostalCodeResolver,
+  GUID: GUIDResolver,
+  HexColorCode: HexColorCodeResolver,
+  HSL: HSLResolver,
+  HSLA: HSLAResolver,
+  RGB: RGBResolver,
+  RGBA: RGBAResolver,
+  IPv4: IPv4Resolver,
+  IPv6: IPv6Resolver,
+  MAC: MACResolver,
+  Port: PortResolver,
+  ISBN: ISBNResolver,
+  USCurrency: USCurrencyResolver,
+  JSON: JSONResolver,
+  JSONObject: JSONObjectResolver
+}

--- a/graphql-server/src/scopes/server/index.ts
+++ b/graphql-server/src/scopes/server/index.ts
@@ -1,73 +1,11 @@
 import gql from "graphql-tag";
+import { makeExecutableSchema } from "apollo-server";
+import {
+  resolvers as customScalarResolvers,
+  typeDefs as customScalarTypeDefs
+} from "@scopes/scalars";
 import _version from "./version";
 import { default as _test, typeDefs as testTypeDefs } from "./test";
-import {
-  DateTimeResolver,
-  EmailAddressResolver,
-  NegativeFloatResolver,
-  NegativeIntResolver,
-  NonNegativeFloatResolver,
-  NonNegativeIntResolver,
-  NonPositiveFloatResolver,
-  NonPositiveIntResolver,
-  PhoneNumberResolver,
-  PositiveFloatResolver,
-  PositiveIntResolver,
-  PostalCodeResolver,
-  UnsignedFloatResolver,
-  UnsignedIntResolver,
-  URLResolver,
-  BigIntResolver,
-  LongResolver,
-  GUIDResolver,
-  HexColorCodeResolver,
-  HSLResolver,
-  HSLAResolver,
-  IPv4Resolver,
-  IPv6Resolver,
-  ISBNResolver,
-  MACResolver,
-  PortResolver,
-  RGBResolver,
-  RGBAResolver,
-  USCurrencyResolver,
-  JSONResolver,
-  JSONObjectResolver
-} from "graphql-scalars";
-
-const JSONTypedef = gql`
-  scalar BigInt
-  scalar DateTime
-  scalar EmailAddress
-  scalar GUID
-  scalar HexColorCode
-  scalar HSL
-  scalar HSLA
-  scalar IPv4
-  scalar IPv6
-  scalar ISBN
-  scalar JSON
-  scalar JSONObject
-  scalar Long
-  scalar MAC
-  scalar NegativeFloat
-  scalar NegativeInt
-  scalar NonNegativeFloat
-  scalar NonNegativeInt
-  scalar NonPositiveFloat
-  scalar NonPositiveInt
-  scalar PhoneNumber
-  scalar Port
-  scalar PositiveFloat
-  scalar PositiveInt
-  scalar PostalCode
-  scalar RGB
-  scalar RGBA
-  scalar UnsignedFloat
-  scalar UnsignedInt
-  scalar URL
-  scalar USCurrency
-`;
 
 const rootTypeDefs = gql`
   "All query for Redwigs"
@@ -87,46 +25,15 @@ const rootTypeDefs = gql`
   }
 `;
 
-export const typeDefs = [rootTypeDefs, JSONTypedef, testTypeDefs];
-
-export const resolver = {
-  query: {
+export const typeDefs = [rootTypeDefs, customScalarTypeDefs, testTypeDefs];
+export const resolvers = {
+  Query: {
     _version
   },
-  mutation: {
+  Mutation: {
     _test
   },
-  scalars: {
-    DateTime: DateTimeResolver,
-    NonPositiveInt: NonPositiveIntResolver,
-    PositiveInt: PositiveIntResolver,
-    NonNegativeInt: NonNegativeIntResolver,
-    NegativeInt: NegativeIntResolver,
-    NonPositiveFloat: NonPositiveFloatResolver,
-    PositiveFloat: PositiveFloatResolver,
-    NonNegativeFloat: NonNegativeFloatResolver,
-    NegativeFloat: NegativeFloatResolver,
-    UnsignedFloat: UnsignedFloatResolver,
-    UnsignedInt: UnsignedIntResolver,
-    BigInt: BigIntResolver,
-    Long: LongResolver,
-    EmailAddress: EmailAddressResolver,
-    URL: URLResolver,
-    PhoneNumber: PhoneNumberResolver,
-    PostalCode: PostalCodeResolver,
-    GUID: GUIDResolver,
-    HexColorCode: HexColorCodeResolver,
-    HSL: HSLResolver,
-    HSLA: HSLAResolver,
-    RGB: RGBResolver,
-    RGBA: RGBAResolver,
-    IPv4: IPv4Resolver,
-    IPv6: IPv6Resolver,
-    MAC: MACResolver,
-    Port: PortResolver,
-    ISBN: ISBNResolver,
-    USCurrency: USCurrencyResolver,
-    JSON: JSONResolver,
-    JSONObject: JSONObjectResolver
-  }
+  ...customScalarResolvers
 };
+
+export const schema = makeExecutableSchema({ typeDefs, resolvers });


### PR DESCRIPTION
Instead of load typedefs and resolvers for each scope, use schema stitching by merge schema into one schema.

For example, the best use case is when reusing Redis command schema into a future features such as Redwigs collection.