### PR TITLE
graphql-server/feat: Add Redis hashes command to GraphQL

### DIFF
--- a/graphql-server/src/scopes/commands/hashes/hdel.ts
+++ b/graphql-server/src/scopes/commands/hashes/hdel.ts
@@ -1,0 +1,31 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+import { convertToJSONOrKeep } from "@utils/json";
+
+export type HDelArgs = {
+  key: string;
+  fields: string[];
+};
+
+export const _hdel: ResolverFunction<HDelArgs> = async (
+  root,
+  { key, fields },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.hdel(key, ...fields);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Delete one or more hash fields. [Read more >>](https://redis.io/commands/hdel)
+    """
+    _hdel(key: String!, fields: [String!]!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/hashes/hexists.ts
+++ b/graphql-server/src/scopes/commands/hashes/hexists.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type HExistsArg = {
+  key: string;
+  field: string;
+};
+
+export const _hexists: ResolverFunction<HExistsArg> = async (
+  root,
+  { key, field },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.hexists(key, field);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Determine if a hash field exists. [Read more >>](https://redis.io/commands/hexists)
+    """
+    _hexists(key: String!, field: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/hashes/hget.ts
+++ b/graphql-server/src/scopes/commands/hashes/hget.ts
@@ -1,0 +1,32 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+import { parseJSONOrKeep } from "@utils/json";
+
+export type HGetArg = {
+  key: string;
+  field: string;
+};
+
+export const _hget: ResolverFunction<HGetArg> = async (
+  root,
+  { key, field },
+  ctx
+): Promise<any> => {
+  try {
+    const reply = await redisClient.hget(key, field);
+    const _reply = parseJSONOrKeep(reply);
+    return _reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Get the value of a hash field. [Read more >>](https://redis.io/commands/hget)
+    """
+    _hget(key: String!, field: String!): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/hashes/hgetall.ts
+++ b/graphql-server/src/scopes/commands/hashes/hgetall.ts
@@ -1,0 +1,32 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+import { parseJSONOrKeep, toMixedJSON, mapToDeepJSON } from "@utils/json";
+
+export type HMGetArg = {
+  key: string;
+};
+
+export const _hgetall: ResolverFunction<HMGetArg> = async (
+  root,
+  { key },
+  ctx
+): Promise<any> => {
+  try {
+    const reply: any[] = await redisClient.hgetall(key);
+    const result = mapToDeepJSON(reply);
+
+    return result;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Get all the fields and values in a hash. [Read more >>](https://redis.io/commands/hgetall)
+    """
+    _hgetall(key: String!): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/hashes/hincrby.ts
+++ b/graphql-server/src/scopes/commands/hashes/hincrby.ts
@@ -1,0 +1,31 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type HIncrByArg = {
+  key: string;
+  field: string;
+  increment: number;
+};
+
+export const _hincrby: ResolverFunction<HIncrByArg> = async (
+  root,
+  { key, field, increment },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.hincrby(key, field, increment);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Increment the integer value of a hash field by the given number. [Read more >>](https://redis.io/commands/hincrby)
+    """
+    _hincrby(key: String!, field: String!, increment: Int!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/hashes/hincrbyfloat.ts
+++ b/graphql-server/src/scopes/commands/hashes/hincrbyfloat.ts
@@ -1,0 +1,32 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type HIncrByArg = {
+  key: string;
+  field: string;
+  increment: number;
+};
+
+export const _hincrbyfloat: ResolverFunction<HIncrByArg> = async (
+  root,
+  { key, field, increment },
+  ctx
+): Promise<any> => {
+  try {
+    const reply = await redisClient.hincrbyfloat(key, field, increment);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Increment the float value of a hash field by the given amount.
+    [Read more >>](https://redis.io/commands/hincrby)
+    """
+    _hincrbyfloat(key: String!, field: String!, increment: Float!): Float
+  }
+`;

--- a/graphql-server/src/scopes/commands/hashes/hkeys.ts
+++ b/graphql-server/src/scopes/commands/hashes/hkeys.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type HKeysArg = {
+  key: string;
+};
+
+export const _hkeys: ResolverFunction<HKeysArg> = async (
+  root,
+  { key },
+  ctx
+): Promise<string[]> => {
+  try {
+    const reply = await redisClient.hkeys(key);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Get all the fields in a hash. [Read more >>](https://redis.io/commands/hkeys)
+    """
+    _hkeys(key: String!): [String]
+  }
+`;

--- a/graphql-server/src/scopes/commands/hashes/hlen.ts
+++ b/graphql-server/src/scopes/commands/hashes/hlen.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type HLenArg = {
+  key: string;
+};
+
+export const _hlen: ResolverFunction<HLenArg> = async (
+  root,
+  { key },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.hlen(key);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Get the number of fields in a hash. [Read more >>](https://redis.io/commands/hlen)
+    """
+    _hlen(key: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/hashes/hmget.ts
+++ b/graphql-server/src/scopes/commands/hashes/hmget.ts
@@ -1,0 +1,36 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+import { parseJSONOrKeep } from "@utils/json";
+import _ from "lodash";
+
+export type HMGetArg = {
+  key: string;
+  fields: string[];
+};
+
+export const _hmget: ResolverFunction<HMGetArg> = async (
+  root,
+  { key, fields },
+  ctx
+): Promise<any> => {
+  try {
+    const reply: any[] = await redisClient.hmget(key, ...fields);
+    const result = _.zipObject(
+      fields,
+      reply.map(v => parseJSONOrKeep(v))
+    );
+    return result;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Get the values of all the given hash fields. [Read more >>](https://redis.io/commands/hmget)
+    """
+    _hmget(key: String!, fields: [String!]!): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/hashes/hmset.ts
+++ b/graphql-server/src/scopes/commands/hashes/hmset.ts
@@ -1,0 +1,37 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+import { convertToJSONOrKeep } from "@utils/json";
+
+export type HMSetArg = {
+  key: string;
+  data: any[];
+};
+
+export const _hmset: ResolverFunction<HMSetArg> = async (
+  root,
+  { key, data },
+  ctx
+): Promise<any> => {
+  try {
+    const _data = Object.keys(data)
+      .map(key => [key, convertToJSONOrKeep(data[key])])
+      .flat();
+    const reply = await redisClient.hmset(key, _data);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Get the length of the value of a hash field. [Read more >>](https://redis.io/commands/hmset)
+    """
+    _hmset(key: String!, data: JSON!): String
+      @deprecated(
+        reason: "HMSET is deprecated as Redis 4.0. Use _hset instead!."
+      )
+  }
+`;

--- a/graphql-server/src/scopes/commands/hashes/hscan.ts
+++ b/graphql-server/src/scopes/commands/hashes/hscan.ts
@@ -1,0 +1,44 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { ScanArg, ScanResult, doScan, ScanType } from "../keys/scan";
+
+export type HScanArg = { key: string } & ScanArg;
+
+export const typeResolvers = {
+  RedisSScanResult: {
+    _next: async (args: ScanResult): Promise<ScanResult> => {
+      return await doScan({
+        scanCommand: ScanType.HSCAN,
+        args,
+        prevArgs: args._prevArgs
+      });
+    }
+  }
+};
+
+export const _hscan: ResolverFunction<HScanArg> = async (
+  root,
+  args,
+  ctx
+): Promise<ScanResult> => {
+  try {
+    return await doScan({ scanCommand: ScanType.HSCAN, args });
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Incrementally iterate hash fields and associated values. [Read more >>](https://redis.io/commands/hscan)
+    """
+    _hscan(
+      key: String!
+      cursor: Int!
+      match: String
+      count: Int
+      type: KeyType
+    ): RedisScanResult
+  }
+`;

--- a/graphql-server/src/scopes/commands/hashes/hset.ts
+++ b/graphql-server/src/scopes/commands/hashes/hset.ts
@@ -1,0 +1,34 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+import { convertToJSONOrKeep } from "@utils/json";
+
+export type HSetArg = {
+  key: string;
+  data: any[];
+};
+
+export const _hset: ResolverFunction<HSetArg> = async (
+  root,
+  { key, data },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const args = Object.keys(data)
+      .map(key => [key, convertToJSONOrKeep(data[key])])
+      .flat();
+    const reply = await redisClient.send_command("hset", key, ...args);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Set the string value of a hash field. [Read more >>](https://redis.io/commands/hset)
+    """
+    _hset(key: String!, data: JSON!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/hashes/hsetnx.ts
+++ b/graphql-server/src/scopes/commands/hashes/hsetnx.ts
@@ -1,0 +1,33 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+import { convertToJSONOrKeep } from "@utils/json";
+
+export type HSetNXArg = {
+  key: string;
+  field: string;
+  value: any;
+};
+
+export const _hsetnx: ResolverFunction<HSetNXArg> = async (
+  root,
+  { key, field, value },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const _value = convertToJSONOrKeep(value);
+    const reply = await redisClient.hsetnx(key, field, _value);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Set the value of a hash field, only if the field does not exist. [Read more >>](https://redis.io/commands/hsetnx)
+    """
+    _hsetnx(key: String!, field: String!, value: JSON!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/hashes/hstrlen.ts
+++ b/graphql-server/src/scopes/commands/hashes/hstrlen.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type HStrlenArg = {
+  key: string;
+  field: string;
+};
+
+export const _hstrlen: ResolverFunction<HStrlenArg> = async (
+  root,
+  { key, field },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.send_command("hstrlen", key, field);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Get the length of the value of a hash field. [Read more >>](https://redis.io/commands/hstrlen)
+    """
+    _hstrlen(key: String!, field: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/hashes/hvals.ts
+++ b/graphql-server/src/scopes/commands/hashes/hvals.ts
@@ -1,0 +1,31 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+import { parseJSONOrKeep } from "@utils/json";
+
+export type HValsArg = {
+  key: string;
+};
+
+export const _hvals: ResolverFunction<HValsArg> = async (
+  root,
+  { key },
+  ctx
+): Promise<any[]> => {
+  try {
+    const reply: string[] = await redisClient.hvals(key);
+    const result = reply.map(v => parseJSONOrKeep(v));
+    return result;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Get all the values in a hash. [Read more >>](https://redis.io/commands/hvals)
+    """
+    _hvals(key: String!): [JSON]
+  }
+`;

--- a/graphql-server/src/scopes/commands/hashes/index.ts
+++ b/graphql-server/src/scopes/commands/hashes/index.ts
@@ -1,0 +1,58 @@
+import { typeDefs as hsetTypeDefs, _hset } from "./hset";
+import { typeDefs as hmsetTypeDefs, _hmset } from "./hmset";
+import { typeDefs as hsetnxTypeDefs, _hsetnx } from "./hsetnx";
+import { typeDefs as hgetTypeDefs, _hget } from "./hget";
+import { typeDefs as hmgetTypeDefs, _hmget } from "./hmget";
+import { typeDefs as hgetAllTypeDefs, _hgetall } from "./hgetall";
+import { typeDefs as hlenTypeDefs, _hlen } from "./hlen";
+import { typeDefs as hkeysTypeDefs, _hkeys } from "./hkeys";
+import { typeDefs as hexistsTypeDefs, _hexists } from "./hexists";
+import { typeDefs as hstrlenTypeDefs, _hstrlen } from "./hstrlen";
+import { typeDefs as hvalsTypeDefs, _hvals } from "./hvals";
+import { typeDefs as hincrbyTypeDefs, _hincrby } from "./hincrby";
+import {
+  typeDefs as hincrbyfloatTypeDefs,
+  _hincrbyfloat
+} from "./hincrbyfloat";
+import { typeDefs as hdelTypeDefs, _hdel } from "./hdel";
+import { typeDefs as hscanTypeDefs, _hscan } from "./hscan";
+
+export const typeDefs = [
+  hsetTypeDefs,
+  hmsetTypeDefs,
+  hsetnxTypeDefs,
+  hgetTypeDefs,
+  hmgetTypeDefs,
+  hgetAllTypeDefs,
+  hlenTypeDefs,
+  hkeysTypeDefs,
+  hexistsTypeDefs,
+  hstrlenTypeDefs,
+  hvalsTypeDefs,
+  hincrbyTypeDefs,
+  hincrbyfloatTypeDefs,
+  hdelTypeDefs,
+  hscanTypeDefs
+];
+
+export const resolvers = {
+  Query: {
+    _hget,
+    _hmget,
+    _hgetall,
+    _hlen,
+    _hkeys,
+    _hexists,
+    _hstrlen,
+    _hvals,
+    _hscan
+  },
+  Mutation: {
+    _hset,
+    _hmset,
+    _hsetnx,
+    _hincrby,
+    _hincrbyfloat,
+    _hdel
+  }
+};

--- a/graphql-server/src/scopes/commands/index.ts
+++ b/graphql-server/src/scopes/commands/index.ts
@@ -20,6 +20,10 @@ import {
   resolvers as setsCommandResolver,
   typeDefs as setsTypeDefs
 } from "./sets";
+import {
+  resolvers as hashCommandResolver,
+  typeDefs as hashTypeDefs
+} from "./hashes";
 import { makeExecutableSchema } from "apollo-server";
 
 const redisTypeDefs = gql`
@@ -59,7 +63,8 @@ export const typeDefs = [
   ...stringTypeDefs,
   ...keysTypeDefs,
   ...connectionsTypeDefs,
-  ...setsTypeDefs
+  ...setsTypeDefs,
+  ...hashTypeDefs
 ];
 
 export const resolvers = {
@@ -67,13 +72,15 @@ export const resolvers = {
     ...stringCommandResolvers.query,
     ...keysCommandResolver.query,
     ...connectionsCommandResolver.query,
-    ...setsCommandResolver.query
+    ...setsCommandResolver.query,
+    ...hashCommandResolver.Query
   },
   Mutation: {
     ...stringCommandResolvers.mutation,
     ...keysCommandResolver.mutation,
     ...connectionsCommandResolver.mutation,
-    ...setsCommandResolver.mutation
+    ...setsCommandResolver.mutation,
+    ...hashCommandResolver.Mutation
   },
   Subscription: {},
   ...keysCommandResolver.types,

--- a/graphql-server/src/utils/json.ts
+++ b/graphql-server/src/utils/json.ts
@@ -1,0 +1,26 @@
+import _ from "lodash";
+
+export const parseJSONOrKeep = (value: any): JSON | any => {
+  try {
+    const json = JSON.parse(value);
+    return json;
+  } catch {
+    return value;
+  }
+};
+
+export const convertToJSONOrKeep = (data: any): string | any =>
+  typeof data === "object" ? JSON.stringify(data) : data;
+
+export const toMixedJSON = (object: any) => (key: number) => ({
+  [key]: parseJSONOrKeep(object[key])
+});
+
+export const mapToDeepJSON = (map: any) => {
+  const arrayOfJSON = _.chain(map)
+    .keys()
+    .map(toMixedJSON(map))
+    .value();
+
+  return _.merge({}, ...arrayOfJSON);
+};

--- a/graphql-server/tsconfig.json
+++ b/graphql-server/tsconfig.json
@@ -10,6 +10,7 @@
     "paths": {
       "@scopes/*": ["scopes/*"],
       "@adapters/*": ["adapters/*"],
+      "@utils/*": ["utils/*"],
       "@typings": ["typings"]
     }
   }


### PR DESCRIPTION
This PR mostly adds a feature for GraphQL server: add Redis hashes command.

Also, for an additional fix or refactor for scan, now can handle HSCAN that basically convert scan result to a JSON objects.