### PR TITLE
graphql-server/feat: Add Redis HyperLogLog commands to GraphQL

### DIFF
--- a/graphql-server/src/scopes/commands/hyperloglog/index.ts
+++ b/graphql-server/src/scopes/commands/hyperloglog/index.ts
@@ -1,0 +1,10 @@
+import { typeDefs as pfaddTypeDefs, _pfadd } from "./pfadd";
+import { typeDefs as pfcountTypeDefs, _pfcount } from "./pfcount";
+import { typeDefs as pfmergeTypeDefs, _pfmerge } from "./pfmerge";
+
+export const typeDefs = [pfaddTypeDefs, pfcountTypeDefs, pfmergeTypeDefs];
+export const resolvers = {
+  Query: { _pfcount },
+  Mutation: { _pfadd, _pfmerge },
+  Subscription: {}
+};

--- a/graphql-server/src/scopes/commands/hyperloglog/pfadd.ts
+++ b/graphql-server/src/scopes/commands/hyperloglog/pfadd.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type PFAddArgs = {
+  key: string;
+  elements: string[];
+};
+
+export const _pfadd: ResolverFunction<PFAddArgs> = async (
+  root,
+  { key, elements },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.pfadd(key, ...elements);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Adds the specified elements to the specified HyperLogLog. [Read more >>](https://redis.io/commands/pfadd)
+    """
+    _pfadd(key: String!, elements: [String!]!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/hyperloglog/pfcount.ts
+++ b/graphql-server/src/scopes/commands/hyperloglog/pfcount.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type PFCountArgs = {
+  keys: string[];
+};
+
+export const _pfcount: ResolverFunction<PFCountArgs> = async (
+  root,
+  { keys },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.pfcount(...keys);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Return the approximated cardinality of the set(s) observed by the HyperLogLog at key(s).
+    [Read more >>](https://redis.io/commands/pfadd)
+    """
+    _pfcount(keys: [String!]!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/hyperloglog/pfmerge.ts
+++ b/graphql-server/src/scopes/commands/hyperloglog/pfmerge.ts
@@ -1,0 +1,31 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type PFMergeArgs = {
+  destkey: string;
+  sourcekey: string[];
+};
+
+export const _pfmerge: ResolverFunction<PFMergeArgs> = async (
+  root,
+  { destkey, sourcekey },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.pfmerge(destkey, ...sourcekey);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Merge N different HyperLogLogs into a single one.
+    [Read more >>](https://redis.io/commands/pfmerge)
+    """
+    _pfmerge(destkey: String!, sourcekey: [String!]!): String
+  }
+`;

--- a/graphql-server/src/scopes/commands/index.ts
+++ b/graphql-server/src/scopes/commands/index.ts
@@ -29,6 +29,10 @@ import {
   resolvers as geoCommandResolver,
   typeDefs as geoTypeDefs
 } from "./geo";
+import {
+  resolvers as hyperLogLogCommandResolver,
+  typeDefs as hyperLogLogTypeDefs
+} from "./hyperloglog";
 
 const redisTypeDefs = gql`
   scalar OK
@@ -69,7 +73,8 @@ export const typeDefs = [
   ...connectionsTypeDefs,
   ...setsTypeDefs,
   ...hashTypeDefs,
-  ...geoTypeDefs
+  ...geoTypeDefs,
+  ...hyperLogLogTypeDefs
 ];
 
 export const resolvers = {
@@ -79,7 +84,8 @@ export const resolvers = {
     ...connectionsCommandResolver.query,
     ...setsCommandResolver.query,
     ...hashCommandResolver.Query,
-    ...geoCommandResolver.Query
+    ...geoCommandResolver.Query,
+    ...hyperLogLogCommandResolver.Query
   },
   Mutation: {
     ...stringCommandResolvers.mutation,
@@ -87,7 +93,8 @@ export const resolvers = {
     ...connectionsCommandResolver.mutation,
     ...setsCommandResolver.mutation,
     ...hashCommandResolver.Mutation,
-    ...geoCommandResolver.Mutation
+    ...geoCommandResolver.Mutation,
+    ...hyperLogLogCommandResolver.Mutation
   },
   Subscription: {},
   ...keysCommandResolver.types,


### PR DESCRIPTION
This PR implements Redis HyperLogLog commands to GraphQL.