### PR TITLE
graphql-server/feat: Add Redis List commands to GraphQL

### DIFF
--- a/graphql-server/src/scopes/commands/index.ts
+++ b/graphql-server/src/scopes/commands/index.ts
@@ -33,6 +33,10 @@ import {
   resolvers as hyperLogLogCommandResolver,
   typeDefs as hyperLogLogTypeDefs
 } from "./hyperloglog";
+import {
+  resolvers as listCommandResolver,
+  typeDefs as listTypeDefs
+} from "./lists";
 
 const redisTypeDefs = gql`
   scalar OK
@@ -74,7 +78,8 @@ export const typeDefs = [
   ...setsTypeDefs,
   ...hashTypeDefs,
   ...geoTypeDefs,
-  ...hyperLogLogTypeDefs
+  ...hyperLogLogTypeDefs,
+  ...listTypeDefs
 ];
 
 export const resolvers = {
@@ -85,7 +90,8 @@ export const resolvers = {
     ...setsCommandResolver.query,
     ...hashCommandResolver.Query,
     ...geoCommandResolver.Query,
-    ...hyperLogLogCommandResolver.Query
+    ...hyperLogLogCommandResolver.Query,
+    ...listCommandResolver.Query
   },
   Mutation: {
     ...stringCommandResolvers.mutation,
@@ -94,7 +100,8 @@ export const resolvers = {
     ...setsCommandResolver.mutation,
     ...hashCommandResolver.Mutation,
     ...geoCommandResolver.Mutation,
-    ...hyperLogLogCommandResolver.Mutation
+    ...hyperLogLogCommandResolver.Mutation,
+    ...listCommandResolver.Mutation
   },
   Subscription: {},
   ...keysCommandResolver.types,

--- a/graphql-server/src/scopes/commands/lists/blpop.ts
+++ b/graphql-server/src/scopes/commands/lists/blpop.ts
@@ -1,0 +1,34 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type BLPopArgs = {
+  keys: string[];
+  timeout: number;
+};
+
+export const _blpop: ResolverFunction<BLPopArgs> = async (
+  root,
+  { keys, timeout },
+  ctx
+): Promise<string[]> => {
+  try {
+    const args = [...keys, timeout];
+    const reply = await redisClient.send_command("blpop", ...args);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **BLPOP key [key ...] timeout**
+
+    Remove and get the first element in a list, or block until one is available.
+    [Read more >>](https://redis.io/commands/blpop)
+    """
+    _blpop(keys: [String!]!, timeout: Int!): [String]
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/brpop.ts
+++ b/graphql-server/src/scopes/commands/lists/brpop.ts
@@ -1,0 +1,34 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type BRPopArgs = {
+  keys: string[];
+  timeout: number;
+};
+
+export const _brpop: ResolverFunction<BRPopArgs> = async (
+  root,
+  { keys, timeout },
+  ctx
+): Promise<string[]> => {
+  try {
+    const args = [...keys, timeout];
+    const reply = await redisClient.send_command("brpop", ...args);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **BRPOP key [key ...] timeout**
+
+    Remove and get the last element in a list, or block until one is available
+    [Read more >>](https://redis.io/commands/blpop)
+    """
+    _brpop(keys: [String!]!, timeout: Int!): [String]
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/brpoplpush.ts
+++ b/graphql-server/src/scopes/commands/lists/brpoplpush.ts
@@ -1,0 +1,40 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type BRPopLPushArgs = {
+  source: string;
+  destination: string;
+  timeout: number;
+};
+
+export const _brpoplpush: ResolverFunction<BRPopLPushArgs> = async (
+  root,
+  { source, destination, timeout },
+  ctx
+): Promise<string> => {
+  try {
+    const reply = await redisClient.send_command(
+      "brpoplpush",
+      source,
+      destination,
+      timeout
+    );
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **BRPOPLPUSH source destination timeout**
+
+    Pop an element from a list, push it to another list and return it;
+    or block until one is available.
+    [Read more >>](https://redis.io/commands/brpoplpush)
+    """
+    _brpoplpush(source: String!, destination: String!, timeout: Int!): String
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/index.ts
+++ b/graphql-server/src/scopes/commands/lists/index.ts
@@ -1,0 +1,62 @@
+import { typeDefs as blpopTypeDefs, _blpop } from "./blpop";
+import { typeDefs as brpoplpushTypeDefs, _brpoplpush } from "./brpoplpush";
+import { typeDefs as brpopTypeDefs, _brpop } from "./brpop";
+import { typeDefs as lindexTypeDefs, _lindex } from "./lindex";
+import { typeDefs as linsertTypeDefs, _linsert } from "./linsert";
+import { typeDefs as llenTypeDefs, _llen } from "./llen";
+import { typeDefs as lpopTypeDefs, _lpop } from "./lpop";
+import { typeDefs as lpushTypeDefs, _lpush } from "./lpush";
+import { typeDefs as lpushxTypeDefs, _lpushx } from "./lpushx";
+import { typeDefs as lrangeTypeDefs, _lrange } from "./lrange";
+import { typeDefs as lremTypeDefs, _lrem } from "./lrem";
+import { typeDefs as lsetTypeDefs, _lset } from "./lset";
+import { typeDefs as ltrimTypeDefs, _ltrim } from "./ltrim";
+import { typeDefs as rpoplpushTypeDefs, _rpoplpush } from "./rpoplpush";
+import { typeDefs as rpopTypeDefs, _rpop } from "./rpop";
+import { typeDefs as rpushTypeDefs, _rpush } from "./rpush";
+import { typeDefs as rpushxTypeDefs, _rpushx } from "./rpushx";
+
+export const typeDefs = [
+  blpopTypeDefs,
+  brpoplpushTypeDefs,
+  brpopTypeDefs,
+  lindexTypeDefs,
+  linsertTypeDefs,
+  llenTypeDefs,
+  lpopTypeDefs,
+  lpushTypeDefs,
+  lpushxTypeDefs,
+  lrangeTypeDefs,
+  lremTypeDefs,
+  lsetTypeDefs,
+  ltrimTypeDefs,
+  rpoplpushTypeDefs,
+  rpopTypeDefs,
+  rpushTypeDefs,
+  rpushxTypeDefs
+];
+
+export const resolvers = {
+  Query: {
+    _lindex,
+    _llen,
+    _lrange
+  },
+  Mutation: {
+    _blpop,
+    _brpop,
+    _brpoplpush,
+    _linsert,
+    _lpop,
+    _lpush,
+    _lpushx,
+    _lrem,
+    _lset,
+    _ltrim,
+    _rpop,
+    _rpoplpush,
+    _rpush,
+    _rpushx
+  },
+  Subscription: {}
+};

--- a/graphql-server/src/scopes/commands/lists/lindex.ts
+++ b/graphql-server/src/scopes/commands/lists/lindex.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type LIndexArgs = {
+  key: string;
+  index: number;
+};
+
+export const _lindex: ResolverFunction<LIndexArgs> = async (
+  root,
+  { key, index },
+  ctx
+): Promise<string> => {
+  try {
+    const reply = await redisClient.lindex(key, index);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Get an element from a list by its index. [Read more >>](https://redis.io/commands/lindex)
+    """
+    _lindex(key: String!, index: Int!): String
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/linsert.ts
+++ b/graphql-server/src/scopes/commands/lists/linsert.ts
@@ -1,0 +1,46 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export enum ListInsertReference {
+  BEFORE = "BEFORE",
+  AFTER = "AFTER"
+}
+
+export type LInsertArgs = {
+  key: string;
+  ref: ListInsertReference;
+  pivot: string;
+  element: any;
+};
+
+export const _linsert: ResolverFunction<LInsertArgs> = async (
+  root,
+  { key, ref, pivot, element },
+  ctx
+): Promise<number> => {
+  try {
+    const reply = await redisClient.linsert(key, ref, pivot, element);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  enum ListInsertReference {
+    BEFORE
+    AFTER
+  }
+  extend type Mutation {
+    """
+    Insert an element before or after another element in a list. [Read more >>](https://redis.io/commands/linsert)
+    """
+    _linsert(
+      key: String!
+      ref: ListInsertReference!
+      pivot: String!
+      element: JSON!
+    ): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/llen.ts
+++ b/graphql-server/src/scopes/commands/lists/llen.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type LLenArgs = {
+  key: string;
+};
+
+export const _llen: ResolverFunction<LLenArgs> = async (
+  root,
+  { key },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.llen(key);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Get the length of a list. [Read more >>](https://redis.io/commands/llen)
+    """
+    _llen(key: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/lpop.ts
+++ b/graphql-server/src/scopes/commands/lists/lpop.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type LPopArgs = {
+  key: string;
+};
+
+export const _lpop: ResolverFunction<LPopArgs> = async (
+  root,
+  { key },
+  ctx
+): Promise<string> => {
+  try {
+    const reply = await redisClient.lpop(key);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Remove and get the first element in a list. [Read more >>](https://redis.io/commands/lpop)
+    """
+    _lpop(key: String!): String
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/lpush.ts
+++ b/graphql-server/src/scopes/commands/lists/lpush.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type LPushArgs = {
+  key: string;
+  elements: string[];
+};
+
+export const _lpush: ResolverFunction<LPushArgs> = async (
+  root,
+  { key, elements },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.lpush(key, ...elements);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Prepend one or multiple elements to a list. [Read more >>](https://redis.io/commands/lpush)
+    """
+    _lpush(key: String!, elements: [String!]!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/lpushx.ts
+++ b/graphql-server/src/scopes/commands/lists/lpushx.ts
@@ -1,0 +1,31 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type LPushXArgs = {
+  key: string;
+  elements: string[];
+};
+
+export const _lpushx: ResolverFunction<LPushXArgs> = async (
+  root,
+  { key, elements },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const args = [key, ...elements];
+    const reply = await redisClient.send_command("lpushx", ...args);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Prepend an element to a list, only if the list exists. [Read more >>](https://redis.io/commands/lpushx)
+    """
+    _lpushx(key: String!, elements: [String!]!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/lrange.ts
+++ b/graphql-server/src/scopes/commands/lists/lrange.ts
@@ -1,0 +1,31 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type LRangeArgs = {
+  key: string;
+  start: number;
+  stop: number;
+};
+
+export const _lrange: ResolverFunction<LRangeArgs> = async (
+  root,
+  { key, start, stop },
+  ctx
+): Promise<string[]> => {
+  try {
+    const reply = await redisClient.lrange(key, start, stop);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Get a range of elements from a list. [Read more >>](https://redis.io/commands/lrange)
+    """
+    _lrange(key: String!, start: Int!, stop: Int!): [String]
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/lrem.ts
+++ b/graphql-server/src/scopes/commands/lists/lrem.ts
@@ -1,0 +1,31 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type LRemArgs = {
+  key: string;
+  count: number;
+  element: any;
+};
+
+export const _lrem: ResolverFunction<LRemArgs> = async (
+  root,
+  { key, count, element },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.lrem(key, count, element);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Remove elements from a list. [Read more >>](https://redis.io/commands/lrem)
+    """
+    _lrem(key: String!, count: Int!, element: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/lset.ts
+++ b/graphql-server/src/scopes/commands/lists/lset.ts
@@ -1,0 +1,31 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type LSetArgs = {
+  key: string;
+  index: number;
+  element: any;
+};
+
+export const _lset: ResolverFunction<LSetArgs> = async (
+  root,
+  { key, index, element },
+  ctx
+): Promise<string> => {
+  try {
+    const reply = await redisClient.lset(key, index, element);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Set the value of an element in a list by its index. [Read more >>](https://redis.io/commands/lset)
+    """
+    _lset(key: String!, index: Int!, element: String!): String
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/ltrim.ts
+++ b/graphql-server/src/scopes/commands/lists/ltrim.ts
@@ -1,0 +1,31 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type LTrimArgs = {
+  key: string;
+  start: number;
+  stop: number;
+};
+
+export const _ltrim: ResolverFunction<LTrimArgs> = async (
+  root,
+  { key, start, stop },
+  ctx
+): Promise<String> => {
+  try {
+    const reply = await redisClient.ltrim(key, start, stop);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Trim a list to the specified range. [Read more >>](https://redis.io/commands/ltrim)
+    """
+    _ltrim(key: String!, start: Int!, stop: Int!): String
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/rpop.ts
+++ b/graphql-server/src/scopes/commands/lists/rpop.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type RPopArgs = {
+  key: string;
+};
+
+export const _rpop: ResolverFunction<RPopArgs> = async (
+  root,
+  { key },
+  ctx
+): Promise<string> => {
+  try {
+    const reply = await redisClient.rpop(key);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Remove and get the last element in a list. [Read more >>](https://redis.io/commands/rpop)
+    """
+    _rpop(key: String!): String
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/rpoplpush.ts
+++ b/graphql-server/src/scopes/commands/lists/rpoplpush.ts
@@ -1,0 +1,33 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type RPopLPushArgs = {
+  source: string;
+  destination: string;
+};
+
+export const _rpoplpush: ResolverFunction<RPopLPushArgs> = async (
+  root,
+  { source, destination },
+  ctx
+): Promise<string> => {
+  try {
+    const reply = await redisClient.rpoplpush(source, destination);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **RPOPLPUSH source destination**
+
+    Remove the last element in a list, prepend it to another list and return it.
+    [Read more >>](https://redis.io/commands/rpoplpush)
+    """
+    _rpoplpush(source: String!, destination: String!): String
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/rpush.ts
+++ b/graphql-server/src/scopes/commands/lists/rpush.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type RPushArgs = {
+  key: string;
+  elements: string[];
+};
+
+export const _rpush: ResolverFunction<RPushArgs> = async (
+  root,
+  { key, elements },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.rpush(key, ...elements);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Append one or multiple elements to a list. [Read more >>](https://redis.io/commands/rpush)
+    """
+    _rpush(key: String!, elements: [String!]!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/lists/rpushx.ts
+++ b/graphql-server/src/scopes/commands/lists/rpushx.ts
@@ -1,0 +1,31 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type RPushXArgs = {
+  key: string;
+  elements: string[];
+};
+
+export const _rpushx: ResolverFunction<RPushXArgs> = async (
+  root,
+  { key, elements },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const args = [key, ...elements];
+    const reply = await redisClient.send_command("rpushx", ...args);
+    return reply;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    Append an element to a list, only if the list exists. [Read more >>](https://redis.io/commands/rpushx)
+    """
+    _rpushx(key: String!, elements: [String!]!): Int
+  }
+`;


### PR DESCRIPTION
This PR implements Redis List commands to GraphQL.

And also found out that documentation better starts with details. Plan to refactor all of the command documentations later.