### PR TITLE
graphql-server/feat: Add Redis SortedSet commands to GraphQL

### DIFF
--- a/graphql-server/src/scopes/commands/index.ts
+++ b/graphql-server/src/scopes/commands/index.ts
@@ -42,7 +42,7 @@ import {
   typeDefs as sortedSetsTypeDefs
 } from "./sortedsets";
 
-const redisTypeDefs = gql`
+const redisRootTypeDefs = gql`
   scalar OK
   scalar Errors
   scalar RespBulk
@@ -75,7 +75,7 @@ const customScalarResolver = {
 
 export const typeDefs = [
   customScalarTypeDefs,
-  redisTypeDefs,
+  redisRootTypeDefs,
   ...stringTypeDefs,
   ...keysTypeDefs,
   ...connectionsTypeDefs,

--- a/graphql-server/src/scopes/commands/index.ts
+++ b/graphql-server/src/scopes/commands/index.ts
@@ -37,6 +37,10 @@ import {
   resolvers as listCommandResolver,
   typeDefs as listTypeDefs
 } from "./lists";
+import {
+  resolvers as sortedSetsCommandResolver,
+  typeDefs as sortedSetsTypeDefs
+} from "./sortedsets";
 
 const redisTypeDefs = gql`
   scalar OK
@@ -79,7 +83,8 @@ export const typeDefs = [
   ...hashTypeDefs,
   ...geoTypeDefs,
   ...hyperLogLogTypeDefs,
-  ...listTypeDefs
+  ...listTypeDefs,
+  ...sortedSetsTypeDefs
 ];
 
 export const resolvers = {
@@ -91,7 +96,8 @@ export const resolvers = {
     ...hashCommandResolver.Query,
     ...geoCommandResolver.Query,
     ...hyperLogLogCommandResolver.Query,
-    ...listCommandResolver.Query
+    ...listCommandResolver.Query,
+    ...sortedSetsCommandResolver.Query
   },
   Mutation: {
     ...stringCommandResolvers.mutation,
@@ -101,7 +107,8 @@ export const resolvers = {
     ...hashCommandResolver.Mutation,
     ...geoCommandResolver.Mutation,
     ...hyperLogLogCommandResolver.Mutation,
-    ...listCommandResolver.Mutation
+    ...listCommandResolver.Mutation,
+    ...sortedSetsCommandResolver.Mutation
   },
   Subscription: {},
   ...keysCommandResolver.types,

--- a/graphql-server/src/scopes/commands/sortedsets/bzpopmax.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/bzpopmax.ts
@@ -1,0 +1,45 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+import _ from "lodash";
+
+export type BZPopMaxArgs = {
+  keys: string[];
+  timeout: number;
+};
+
+export const _bzpopmax: ResolverFunction<BZPopMaxArgs> = async (
+  root,
+  { keys, timeout },
+  ctx
+): Promise<string | number> => {
+  try {
+    const args: any[] = [...keys, timeout];
+    const reply = await redisClient.send_command("bzpopmax", ...args);
+    const result = _.merge(
+      {},
+      ..._.chain(reply)
+        .chunk(3)
+        .map(([key, member, score]) => ({
+          [key]: { [member]: parseFloat(score) }
+        }))
+        .value()
+    );
+
+    return result;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **BZPOPMAX key [key ...] timeout**
+
+    Remove and return the member with the highest score from one or more sorted sets, or block until one is available.
+    [Read more >>](https://redis.io/commands/bzpopmax)
+    """
+    _bzpopmax(keys: [String!]!, timeout: Int!): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/bzpopmin.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/bzpopmin.ts
@@ -1,0 +1,45 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+import _ from "lodash";
+
+export type BZPopMinArgs = {
+  keys: string[];
+  timeout: number;
+};
+
+export const _bzpopmin: ResolverFunction<BZPopMinArgs> = async (
+  root,
+  { keys, timeout },
+  ctx
+): Promise<string | number> => {
+  try {
+    const args: any[] = [...keys, timeout];
+    const reply = await redisClient.send_command("bzpopmin", ...args);
+    const result = _.merge(
+      {},
+      ..._.chain(reply)
+        .chunk(3)
+        .map(([key, member, score]) => ({
+          [key]: { [member]: parseFloat(score) }
+        }))
+        .value()
+    );
+
+    return result;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **BZPOPMIN key [key ...] timeout**
+
+    Remove and return members with the lowest scores in a sorted set.
+    [Read more >>](https://redis.io/commands/bzpopmin)
+    """
+    _bzpopmin(keys: [String!]!, timeout: Int!): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/index.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/index.ts
@@ -1,0 +1,104 @@
+import { typeDefs as bzpopmaxTypeDefs, _bzpopmax } from "./bzpopmax";
+import { typeDefs as bzpopminTypeDefs, _bzpopmin } from "./bzpopmin";
+import { typeDefs as zaddTypeDefs, _zadd } from "./zadd";
+import { typeDefs as zcardTypeDefs, _zcard } from "./zcard";
+import { typeDefs as zcountTypeDefs, _zcount } from "./zcount";
+import { typeDefs as zincrbyTypeDefs, _zincrby } from "./zincrby";
+import { typeDefs as zinterstoreTypeDefs, _zinterstore } from "./zinterstore";
+import { typeDefs as zlexcountTypeDefs, _zlexcount } from "./zlexcount";
+import { typeDefs as zpopmaxTypeDefs, _zpopmax } from "./zpopmax";
+import { typeDefs as zpopminTypeDefs, _zpopmin } from "./zpopmin";
+import { typeDefs as zrangebylexTypeDefs, _zrangebylex } from "./zrangebylex";
+import {
+  typeDefs as zrangebyscoreTypeDefs,
+  _zrangebyscore
+} from "./zrangebyscore";
+import { typeDefs as zrangeTypeDefs, _zrange } from "./zrange";
+import { typeDefs as zrankbylexTypeDefs, _zrank } from "./zrank";
+import {
+  typeDefs as zremrangebylexTypeDefs,
+  _zremrangebylex
+} from "./zremrangebylex";
+import {
+  typeDefs as zremrangebyrankTypeDefs,
+  _zremrangebyrank
+} from "./zremrangebyrank";
+import {
+  typeDefs as zremrangebyscoreTypeDefs,
+  _zremrangebyscore
+} from "./zremrangebyscore";
+import { typeDefs as zremTypeDefs, _zrem } from "./zrem";
+import {
+  typeDefs as zrevrangebylexTypeDefs,
+  _zrevrangebylex
+} from "./zrevrangebylex";
+import {
+  typeDefs as zrevrangebyscoreTypeDefs,
+  _zrevrangebyscore
+} from "./zrevrangebyscore";
+import { typeDefs as zrevrangeTypeDefs, _zrevrange } from "./zrevrange";
+import { typeDefs as zrevrankTypeDefs, _zrevrank } from "./zrevrank";
+import { typeDefs as zscanTypeDefs, _zscan } from "./zscan";
+import { typeDefs as zscoreTypeDefs, _zscore } from "./zscore";
+import { typeDefs as zunionstoreTypeDefs, _zunionstore } from "./zunionstore";
+
+export const typeDefs = [
+  bzpopmaxTypeDefs,
+  bzpopminTypeDefs,
+  zaddTypeDefs,
+  zcardTypeDefs,
+  zcountTypeDefs,
+  zincrbyTypeDefs,
+  zinterstoreTypeDefs,
+  zlexcountTypeDefs,
+  zpopmaxTypeDefs,
+  zpopminTypeDefs,
+  zrangebylexTypeDefs,
+  zrangebyscoreTypeDefs,
+  zrangeTypeDefs,
+  zrankbylexTypeDefs,
+  zremrangebylexTypeDefs,
+  zremrangebyrankTypeDefs,
+  zremrangebyscoreTypeDefs,
+  zremTypeDefs,
+  zrevrangebylexTypeDefs,
+  zrevrangebyscoreTypeDefs,
+  zrevrangeTypeDefs,
+  zrevrankTypeDefs,
+  zscanTypeDefs,
+  zscoreTypeDefs,
+  zunionstoreTypeDefs
+];
+
+export const resolvers = {
+  Query: {
+    _zcard,
+    _zcount,
+    _zlexcount,
+    _zrange,
+    _zrangebylex,
+    _zrangebyscore,
+    _zrank,
+    _zrevrange,
+    _zrevrangebylex,
+    _zrevrangebyscore,
+    _zrevrank,
+    _zscan,
+    _zscore
+  },
+  Mutation: {
+    _bzpopmax,
+    _bzpopmin,
+    _zadd,
+    _zincrby,
+    _zinterstore,
+    _zpopmax,
+    _zpopmin,
+    _zrem,
+    _zremrangebylex,
+    _zremrangebyrank,
+    _zremrangebyscore,
+    _zunionstore
+  },
+  Subscription: {}
+};

--- a/graphql-server/src/scopes/commands/sortedsets/zadd.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zadd.ts
@@ -1,0 +1,69 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+enum ZAddMode {
+  NX = "NX",
+  XX = "XX"
+}
+
+export type ZAddArgs = {
+  key: string;
+  mode?: ZAddMode;
+  changed?: boolean;
+  incr?: boolean;
+  pairs: {
+    score: number;
+    member: string;
+  }[];
+};
+
+export const _zadd: ResolverFunction<ZAddArgs> = async (
+  root,
+  { key, mode, changed, incr, pairs },
+  ctx
+): Promise<string | number> => {
+  try {
+    const args = [];
+    if (mode) args.push(mode);
+    if (changed === true) args.push("CH");
+    if (incr === true) args.push("INCR");
+
+    const data: any[] = pairs.map(v => [v.score, v.member]).flat();
+    args.push(...data);
+
+    const reply = await redisClient.zadd(key, ...args);
+
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  enum ZAddMode {
+    NX
+    XX
+  }
+
+  input SortedSetPairData {
+    score: Int!
+    member: String!
+  }
+
+  extend type Mutation {
+    """
+    **ZADD key [NX|XX] [CH] [INCR] score member [score member ...]**
+
+    Add one or more members to a sorted set, or update its score if it already exists.
+    [Read more >>](https://redis.io/commands/zadd)
+    """
+    _zadd(
+      key: String!
+      mode: ZAddMode
+      changed: Boolean
+      incr: Boolean
+      pairs: [SortedSetPairData!]!
+    ): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zcard.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zcard.ts
@@ -1,0 +1,32 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type ZCardArgs = {
+  key: string;
+};
+
+export const _zcard: ResolverFunction<ZCardArgs> = async (
+  root,
+  { key },
+  ctx
+): Promise<number> => {
+  try {
+    const reply = await redisClient.zcard(key);
+
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    **ZCARD key**
+
+    Get the number of members in a sorted set. [Read more >>](https://redis.io/commands/zcard)
+    """
+    _zcard(key: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zcount.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zcount.ts
@@ -1,0 +1,34 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type ZCountArgs = {
+  key: string;
+  min: string;
+  max: string;
+};
+
+export const _zcount: ResolverFunction<ZCountArgs> = async (
+  root,
+  { key, min, max },
+  ctx
+): Promise<number> => {
+  try {
+    const reply = await redisClient.zcount(key, min, max);
+
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    **ZCOUNT key min max**
+
+    Count the members in a sorted set with scores within the given values. [Read more >>](https://redis.io/commands/zcount)
+    """
+    _zcount(key: String!, min: String!, max: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zincrby.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zincrby.ts
@@ -1,0 +1,34 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type ZIncrByArgs = {
+  key: string;
+  increment: number;
+  member: string;
+};
+
+export const _zincrby: ResolverFunction<ZIncrByArgs> = async (
+  root,
+  { key, increment, member },
+  ctx
+): Promise<string | number> => {
+  try {
+    const reply = await redisClient.zincrby(key, increment, member);
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **ZINCRBY key increment member**
+
+    Increment the score of a member in a sorted set.
+    [Read more >>](https://redis.io/commands/zincrby)
+    """
+    _zincrby(key: String!, increment: Float!, member: String!): String
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zinterstore.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zinterstore.ts
@@ -1,0 +1,46 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+import { Aggregate } from "./zunionstore";
+
+export type ZInterStoreArgs = {
+  destination: string;
+  numkeys: number;
+  keys: string[];
+  weights?: number[];
+  aggregate?: Aggregate;
+};
+
+export const _zinterstore: ResolverFunction<ZInterStoreArgs> = async (
+  root,
+  { destination, numkeys, keys, weights, aggregate },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const args: any[] = [destination, numkeys, ...keys];
+    if (weights && weights.length > 0) args.push("WEIGHTS", ...weights);
+    if (aggregate) args.push(aggregate);
+    const reply = await redisClient.send_command("zinterstore", ...args);
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **ZINTERSTORE destination numkeys key [key ...] [WEIGHTS weight [weight ...]] [AGGREGATE SUM|MIN|MAX]**
+
+    Intersect multiple sorted sets and store the resulting sorted set in a new key.
+    [Read more >>](https://redis.io/commands/zinterstore)
+    """
+    _zinterstore(
+      destination: String!
+      numkeys: Int!
+      keys: [String!]!
+      weights: [Int]
+      aggregate: Aggregate
+    ): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zlexcount.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zlexcount.ts
@@ -1,0 +1,35 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type ZLexCountArgs = {
+  key: string;
+  min: string;
+  max: string;
+};
+
+export const _zlexcount: ResolverFunction<ZLexCountArgs> = async (
+  root,
+  { key, min, max },
+  ctx
+): Promise<number> => {
+  try {
+    const reply = await redisClient.send_command("zlexcount", key, min, max);
+
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    **ZLEXCOUNT key min max**
+
+    Count the number of members in a sorted set between a given lexicographical range.
+    [Read more >>](https://redis.io/commands/zlexcount)
+    """
+    _zlexcount(key: String!, min: String!, max: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zpopmax.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zpopmax.ts
@@ -1,0 +1,43 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+import _ from "lodash";
+
+export type ZPopMaxArgs = {
+  key: string;
+  count?: number;
+};
+
+export const _zpopmax: ResolverFunction<ZPopMaxArgs> = async (
+  root,
+  { key, count },
+  ctx
+): Promise<string | number> => {
+  try {
+    const args: any[] = [key];
+    if (count) args.push(count);
+    const reply = await redisClient.send_command("zpopmax", ...args);
+    const result = _.merge(
+      {},
+      ..._.chain(reply)
+        .chunk(2)
+        .map(([member, score]) => ({ [member]: parseFloat(score) }))
+        .value()
+    );
+    return result;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **ZPOPMAX key [count]**
+
+    Remove and return members with the highest scores in a sorted set.
+    [Read more >>](https://redis.io/commands/zpopmax)
+    """
+    _zpopmax(key: String!, count: Int): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zpopmin.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zpopmin.ts
@@ -1,0 +1,43 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+import _ from "lodash";
+
+export type ZPopMinArgs = {
+  key: string;
+  count?: number;
+};
+
+export const _zpopmin: ResolverFunction<ZPopMinArgs> = async (
+  root,
+  { key, count },
+  ctx
+): Promise<string | number> => {
+  try {
+    const args: any[] = [key];
+    if (count) args.push(count);
+    const reply = await redisClient.send_command("zpopmin", ...args);
+    const result = _.merge(
+      {},
+      ..._.chain(reply)
+        .chunk(2)
+        .map(([member, score]) => ({ [member]: parseFloat(score) }))
+        .value()
+    );
+    return result;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **ZPOPMIN key [count]**
+
+    Remove and return members with the lowest scores in a sorted set.
+    [Read more >>](https://redis.io/commands/zpopmin)
+    """
+    _zpopmin(key: String!, count: Int): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zrange.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zrange.ts
@@ -1,0 +1,49 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+import _ from "lodash";
+
+export type ZRangeArgs = {
+  key: string;
+  start: number;
+  stop: number;
+  with_scores?: boolean;
+};
+
+export const _zrange: ResolverFunction<ZRangeArgs> = async (
+  root,
+  { key, start, stop, with_scores },
+  ctx
+): Promise<any> => {
+  try {
+    const isWithScores = with_scores === true;
+    const reply = isWithScores
+      ? await redisClient.zrange(key, start, stop, "WITHSCORES")
+      : await redisClient.zrange(key, start, stop);
+
+    const result = isWithScores
+      ? _.merge(
+          {},
+          ..._.chain(reply)
+            .chunk(2)
+            .map(([member, score]) => ({ [member]: parseFloat(score) }))
+            .value()
+        )
+      : reply;
+
+    return result;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    **ZRANGE key start stop [WITHSCORES]**
+
+    Return a range of members in a sorted set, by index. [Read more >>](https://redis.io/commands/zrange)
+    """
+    _zrange(key: String!, start: Int!, stop: Int!, with_scores: Boolean): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zrangebylex.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zrangebylex.ts
@@ -1,0 +1,52 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+import _ from "lodash";
+
+export type Limit = {
+  offset: number;
+  count: number;
+};
+
+export type ZRangeByLexArgs = {
+  key: string;
+  min: string;
+  max: string;
+  limit: Limit;
+};
+
+export const _zrangebylex: ResolverFunction<ZRangeByLexArgs> = async (
+  root,
+  { key, min, max, limit },
+  ctx
+): Promise<string[]> => {
+  try {
+    const args: any[] = [key, min, max];
+    if (limit) args.push("LIMIT", limit.offset, limit.count);
+    const reply = await redisClient.send_command("zrangebylex", ...args);
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  input Limit {
+    offset: Int!
+    count: Int!
+  }
+  extend type Query {
+    """
+    **ZRANGEBYLEX key min max [LIMIT offset count]**
+
+    Return a range of members in a sorted set, by lexicographical range.
+    [Read more >>](https://redis.io/commands/zrangebylex)
+    """
+    _zrangebylex(
+      key: String!
+      min: String!
+      max: String!
+      limit: Limit
+    ): [String]
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zrangebyscore.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zrangebyscore.ts
@@ -1,0 +1,58 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+import _ from "lodash";
+import { Limit } from "./zrangebylex";
+
+export type ZRangeByScoreArgs = {
+  key: string;
+  min: string;
+  max: string;
+  with_scores?: boolean;
+  limit?: Limit;
+};
+
+export const _zrangebyscore: ResolverFunction<ZRangeByScoreArgs> = async (
+  root,
+  { key, min, max, with_scores, limit },
+  ctx
+): Promise<string[]> => {
+  try {
+    const args: any[] = [];
+    const isWithScores = with_scores === true;
+    if (isWithScores) args.push("WITHSCORES");
+    if (limit) args.push("LIMIT", limit.offset, limit.count);
+
+    const reply = await redisClient.zrangebyscore(key, min, max, ...args);
+    const result = isWithScores
+      ? _.merge(
+          {},
+          ..._.chain(reply)
+            .chunk(2)
+            .map(([member, score]) => ({ [member]: parseFloat(score) }))
+            .value()
+        )
+      : reply;
+
+    return result;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    **ZRANGEBYSCORE key min max [WITHSCORES] [LIMIT offset count]**
+
+    Return a range of members in a sorted set, by score. [Read more >>](https://redis.io/commands/zrangebyscore)
+    """
+    _zrangebyscore(
+      key: String!
+      min: String!
+      max: String!
+      with_scores: Boolean
+      limit: Limit
+    ): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zrank.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zrank.ts
@@ -1,0 +1,33 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type ZRankArgs = {
+  key: string;
+  member: string;
+};
+
+export const _zrank: ResolverFunction<ZRankArgs> = async (
+  root,
+  { key, member },
+  ctx
+): Promise<number> => {
+  try {
+    const reply = await redisClient.zrank(key, member);
+
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    **ZRANK key member**
+
+    Determine the index of a member in a sorted set. [Read more >>](https://redis.io/commands/zrank)
+    """
+    _zrank(key: String!, member: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zrem.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zrem.ts
@@ -1,0 +1,33 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type ZRemArgs = {
+  key: string;
+  members: string[];
+};
+
+export const _zrem: ResolverFunction<ZRemArgs> = async (
+  root,
+  { key, members },
+  ctx
+): Promise<string | number> => {
+  try {
+    const reply = await redisClient.zrem(key, ...members);
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **ZREM key member [member ...]**
+
+    Remove one or more members from a sorted set.
+    [Read more >>](https://redis.io/commands/zrem)
+    """
+    _zrem(key: String!, members: [String!]!): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zremrangebylex.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zremrangebylex.ts
@@ -1,0 +1,36 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type ZRemRangeByLexArgs = {
+  key: string;
+  min: string;
+  max: string;
+};
+
+export const _zremrangebylex: ResolverFunction<ZRemRangeByLexArgs> = async (
+  root,
+  { key, min, max },
+  ctx
+): Promise<number> => {
+  try {
+    const args: any[] = [key, min, max];
+
+    const reply = await redisClient.send_command("zremrangebylex", args);
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **ZREMRANGEBYLEX key min max**
+
+    Remove all members in a sorted set between the given lexicographical range.
+    [Read more >>](https://redis.io/commands/zremrangebylex)
+    """
+    _zremrangebylex(key: String!, min: String!, max: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zremrangebyrank.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zremrangebyrank.ts
@@ -1,0 +1,34 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type ZRemRangeByRankArgs = {
+  key: string;
+  start: number;
+  stop: number;
+};
+
+export const _zremrangebyrank: ResolverFunction<ZRemRangeByRankArgs> = async (
+  root,
+  { key, start, stop },
+  ctx
+): Promise<number> => {
+  try {
+    const reply = await redisClient.zremrangebyrank(key, start, stop);
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **ZREMRANGEBYRANK key start stop**
+
+    Remove all members in a sorted set within the given indexes.
+    [Read more >>](https://redis.io/commands/zremrangebyrank)
+    """
+    _zremrangebyrank(key: String!, start: Int!, stop: Int!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zremrangebyscore.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zremrangebyscore.ts
@@ -1,0 +1,34 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type ZRemRangeByScorergs = {
+  key: string;
+  min: string;
+  max: string;
+};
+
+export const _zremrangebyscore: ResolverFunction<ZRemRangeByScorergs> = async (
+  root,
+  { key, min, max },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const reply = await redisClient.zremrangebyscore(key, min, max);
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **ZREMRANGEBYSCORE key min max**
+
+    Remove all members in a sorted set within the given scores.
+    [Read more >>](https://redis.io/commands/zremrangebyscore)
+    """
+    _zremrangebyscore(key: String!, min: String!, max: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zrevrange.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zrevrange.ts
@@ -1,0 +1,55 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+import _ from "lodash";
+
+export type ZRevRangeArgs = {
+  key: string;
+  start: number;
+  stop: number;
+  with_scores?: boolean;
+};
+
+export const _zrevrange: ResolverFunction<ZRevRangeArgs> = async (
+  root,
+  { key, start, stop, with_scores },
+  ctx
+): Promise<any> => {
+  try {
+    const isWithScores = with_scores === true;
+    const reply = isWithScores
+      ? await redisClient.zrevrange(key, start, stop, "WITHSCORES")
+      : await redisClient.zrevrange(key, start, stop);
+
+    const result = isWithScores
+      ? _.merge(
+          {},
+          ..._.chain(reply)
+            .chunk(2)
+            .map(([member, score]) => ({ [member]: parseFloat(score) }))
+            .value()
+        )
+      : reply;
+
+    return result;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    **ZREVRANGE key start stop [WITHSCORES]**
+
+    Return a range of members in a sorted set, by index, with scores ordered from high to low.
+    [Read more >>](https://redis.io/commands/zrevrange)
+    """
+    _zrevrange(
+      key: String!
+      start: Int!
+      stop: Int!
+      with_scores: Boolean
+    ): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zrevrangebylex.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zrevrangebylex.ts
@@ -1,0 +1,49 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+import _ from "lodash";
+
+export type Limit = {
+  offset: number;
+  count: number;
+};
+
+export type ZRevRangeByLexArgs = {
+  key: string;
+  min: string;
+  max: string;
+  limit: Limit;
+};
+
+export const _zrevrangebylex: ResolverFunction<ZRevRangeByLexArgs> = async (
+  root,
+  { key, min, max, limit },
+  ctx
+): Promise<string[]> => {
+  try {
+    const args: any[] = [key, max, min];
+    if (limit) args.push("LIMIT", limit.offset, limit.count);
+
+    const reply = await redisClient.send_command("zrevrangebylex", ...args);
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    **ZREVRANGEBYLEX key max min [LIMIT offset count]**
+
+    Return a range of members in a sorted set, by lexicographical range, ordered from higher to lower strings.
+    [Read more >>](https://redis.io/commands/zrevrangebylex)
+    """
+    _zrevrangebylex(
+      key: String!
+      max: String!
+      min: String!
+      limit: Limit
+    ): [String]
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zrevrangebyscore.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zrevrangebyscore.ts
@@ -1,0 +1,59 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+import _ from "lodash";
+import { Limit } from "./zrangebylex";
+
+export type ZRevRangeByScoreArgs = {
+  key: string;
+  min: string;
+  max: string;
+  with_scores?: boolean;
+  limit?: Limit;
+};
+
+export const _zrevrangebyscore: ResolverFunction<ZRevRangeByScoreArgs> = async (
+  root,
+  { key, min, max, with_scores, limit },
+  ctx
+): Promise<string[]> => {
+  try {
+    const args: any[] = [];
+    const isWithScores = with_scores === true;
+    if (isWithScores) args.push("WITHSCORES");
+    if (limit) args.push("LIMIT", limit.offset, limit.count);
+
+    const reply = await redisClient.zrevrangebyscore(key, max, min, ...args);
+    const result = isWithScores
+      ? _.merge(
+          {},
+          ..._.chain(reply)
+            .chunk(2)
+            .map(([member, score]) => ({ [member]: parseFloat(score) }))
+            .value()
+        )
+      : reply;
+
+    return result;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    **ZRANGEBYSCORE key min max [WITHSCORES] [LIMIT offset count]**
+
+    Return a range of members in a sorted set, by score, with scores ordered from high to low.
+    [Read more >>](https://redis.io/commands/zrevrangebyscore)
+    """
+    _zrevrangebyscore(
+      key: String!
+      max: String!
+      min: String!
+      with_scores: Boolean
+      limit: Limit
+    ): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zrevrank.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zrevrank.ts
@@ -1,0 +1,34 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type ZRevRankArgs = {
+  key: string;
+  member: string;
+};
+
+export const _zrevrank: ResolverFunction<ZRevRankArgs> = async (
+  root,
+  { key, member },
+  ctx
+): Promise<number> => {
+  try {
+    const reply = await redisClient.zrevrank(key, member);
+
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    **ZREVRANK key member**
+
+    Determine the index of a member in a sorted set, with scores ordered from high to low.
+    [Read more >>](https://redis.io/commands/zrevrank)
+    """
+    _zrevrank(key: String!, member: String!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zscan.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zscan.ts
@@ -1,0 +1,46 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+import { ScanArg, ScanResult, doScan, ScanType } from "../keys/scan";
+
+export type ZScanArgs = { key: string } & ScanArg;
+
+export const typeResolvers = {
+  RedisSScanResult: {
+    _next: async (args: ScanResult): Promise<ScanResult> => {
+      return await doScan({
+        scanCommand: ScanType.ZSCAN,
+        args,
+        prevArgs: args._prevArgs
+      });
+    }
+  }
+};
+
+export const _zscan: ResolverFunction<ZScanArgs> = async (
+  root,
+  args,
+  ctx
+): Promise<ScanResult> => {
+  try {
+    return await doScan({ scanCommand: ScanType.ZSCAN, args });
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    Incrementally iterate sorted sets elements and associated scores.
+    [Read more >>](https://redis.io/commands/zscan)
+    """
+    _zscan(
+      key: String!
+      cursor: Int!
+      match: String
+      count: Int
+      type: KeyType
+    ): RedisScanResult
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zscore.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zscore.ts
@@ -1,0 +1,33 @@
+import gql from "graphql-tag";
+import { ResolverFunction } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type ZScoreArgs = {
+  key: string;
+  member: string;
+};
+
+export const _zscore: ResolverFunction<ZScoreArgs> = async (
+  root,
+  { key, member },
+  ctx
+): Promise<string> => {
+  try {
+    const reply = await redisClient.zscore(key, member);
+
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    **ZSCORE key member**
+
+    Get the score associated with the given member in a sorted set. [Read more >>](https://redis.io/commands/zscore)
+    """
+    _zscore(key: String!, member: String!): Float
+  }
+`;

--- a/graphql-server/src/scopes/commands/sortedsets/zunionstore.ts
+++ b/graphql-server/src/scopes/commands/sortedsets/zunionstore.ts
@@ -1,0 +1,56 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export enum Aggregate {
+  SUM = "SUM",
+  MIN = "MIN",
+  MAX = "MAX"
+}
+
+export type ZUnionStoreArgs = {
+  destination: string;
+  numkeys: number;
+  keys: string[];
+  weights?: number[];
+  aggregate?: Aggregate;
+};
+
+export const _zunionstore: ResolverFunction<ZUnionStoreArgs> = async (
+  root,
+  { destination, numkeys, keys, weights, aggregate },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const args: any[] = [destination, numkeys, ...keys];
+    if (weights && weights.length > 0) args.push("WEIGHTS", ...weights);
+    if (aggregate) args.push(aggregate);
+    const reply = await redisClient.send_command("zunionstore", ...args);
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  enum Aggregate {
+    SUM
+    MIN
+    MAX
+  }
+  extend type Mutation {
+    """
+    **ZUNIONSTORE destination numkeys key [key ...] [WEIGHTS weight [weight ...]] [AGGREGATE SUM|MIN|MAX]**
+
+    Add multiple sorted sets and store the resulting sorted set in a new key.
+    [Read more >>](https://redis.io/commands/zunionstore)
+    """
+    _zunionstore(
+      destination: String!
+      numkeys: Int!
+      keys: [String!]!
+      weights: [Int]
+      aggregate: Aggregate
+    ): Int
+  }
+`;


### PR DESCRIPTION
This PR add implementations Redis sorted set commands to GraphQL

Also, refactor renaming redisTypeDefs to redisRootTypeDefs