### PR TITLE
graphql-server/feat: Add Redis PubSub commands to GraphQL

### DIFF
--- a/graphql-server/package.json
+++ b/graphql-server/package.json
@@ -12,8 +12,13 @@
   },
   "dependencies": {
     "apollo-server": "^2.9.16",
+    "apollo-server-express": "^2.10.0",
+    "delay": "^4.3.0",
+    "express": "^4.17.1",
     "graphql": "^14.6.0",
+    "graphql-redis-subscriptions": "^2.1.2",
     "graphql-scalars": "^1.0.6",
+    "graphql-subscriptions": "^1.1.0",
     "graphql-tag": "^2.10.1",
     "graphql-type-uuid": "^0.2.0",
     "ioredis": "^4.14.1",

--- a/graphql-server/src/adapters/pubsub.ts
+++ b/graphql-server/src/adapters/pubsub.ts
@@ -1,0 +1,23 @@
+import Redis from "ioredis";
+import { PubSub } from "apollo-server";
+import { REDWIGS_REDIS_PATTERN_PUBSUB, REDWIGS_REDIS_PUBSUB } from "./redwigs";
+
+export const pubsub = new PubSub();
+export const subscriber = new Redis();
+const publisher = new Redis();
+
+subscriber.psubscribe("*");
+process.on("exit", () => subscriber.punsubscribe("*"));
+
+subscriber.on("pmessage", async (pattern, channel, message) => {
+  if (pattern !== "*") {
+    pubsub.publish(REDWIGS_REDIS_PATTERN_PUBSUB, {
+      _psubscribe: { pattern, channel, message }
+    });
+  }
+});
+
+subscriber.on("message", async (channel, message) => {
+  console.log({ channel, message, y: "r" });
+  pubsub.publish(REDWIGS_REDIS_PUBSUB, { _subscribe: { channel, message } });
+});

--- a/graphql-server/src/adapters/redwigs.ts
+++ b/graphql-server/src/adapters/redwigs.ts
@@ -1,0 +1,12 @@
+import Redis from "ioredis";
+
+const opts = { db: 10 };
+export const redwigsClient = new Redis(opts);
+export const redwigsSubscriber = new Redis(opts);
+export const REDWIGS_PUBSUB_CHANNEL_DATA = "redwigs:redis:pubsub:channels";
+export const REDWIGS_REDIS_PUBSUB = "redwigs:pubsub:common";
+export const REDWIGS_REDIS_PATTERN_PUBSUB = "redwigs:pubsub:pattern";
+
+// export const REDWIGS_PUBSUB_PATTERN_CHANNEL_DATA =
+//   "redwigs:redis:pubsub:pattern:data";
+// export const REDWIGS_REDIS_UNSUBSCRIBE_ALL = "redwigs:redis:unsubscribe";

--- a/graphql-server/src/app.ts
+++ b/graphql-server/src/app.ts
@@ -1,15 +1,38 @@
-import { ApolloServer, IResolvers, mergeSchemas } from "apollo-server";
-import listenHandler from "./handlers/listen";
+import { ApolloServer, mergeSchemas } from "apollo-server-express";
 import { schema as serverSchema } from "./scopes/server";
 import { schema as redisCommandSchema } from "./scopes/commands";
+import express, { Request, Response } from "express";
+import http from "http";
+import listenHandler from "@handlers/listen";
+import {
+  onSubscriptionConnect,
+  onSubscriptionDisconnect
+} from "@handlers/subscriber";
+
+import { getChannelNamesFromQuery } from "@utils/subscribe";
 
 const mergedSchema = mergeSchemas({
   schemas: [redisCommandSchema, serverSchema]
 });
 
-const serverOptions = {
-  schema: mergedSchema
-};
+const PORT = 4000;
+const app = express();
+const httpServer = http.createServer(app);
 
-const server = new ApolloServer(serverOptions);
-server.listen().then(listenHandler);
+app.use("/", (req: Request, res: Response) =>
+  res
+    .status(404)
+    .send({ message: "Resource Not Found", endpoints: { graphql: "/graphql" } })
+);
+
+const server = new ApolloServer({
+  schema: mergedSchema,
+  subscriptions: {
+    onConnect: onSubscriptionConnect,
+    onDisconnect: onSubscriptionDisconnect
+  }
+});
+server.applyMiddleware({ app });
+server.installSubscriptionHandlers(httpServer);
+
+httpServer.listen(PORT, listenHandler(server, PORT));

--- a/graphql-server/src/handlers/listen.ts
+++ b/graphql-server/src/handlers/listen.ts
@@ -1,5 +1,10 @@
-const listenHandler = ({ url }) => {
-  console.log(`🚀  Server ready at ${url}`);
+import { ApolloServer } from "apollo-server-express";
+
+const listenHandler = (server: ApolloServer, port: number) => () => {
+  console.log(`RedWigs ready at http://localhost:${port}${server.graphqlPath}`);
+  console.log(
+    `Redwigs Subscriptions ready at ws://localhost:${port}${server.subscriptionsPath}`
+  );
 };
 
 export default listenHandler;

--- a/graphql-server/src/handlers/subscriber.ts
+++ b/graphql-server/src/handlers/subscriber.ts
@@ -1,0 +1,94 @@
+import { DocumentNode } from "graphql";
+import gql from "graphql-tag";
+import {
+  redwigsClient,
+  // REDWIGS_REDIS_UNSUBSCRIBE_ALL,
+  redwigsSubscriber
+} from "@adapters/redwigs";
+import { EventEmitter } from "events";
+import { ConnectionContext } from "subscriptions-transport-ws";
+import WebSocket from "ws";
+
+const ev = new EventEmitter();
+redwigsSubscriber.on("message", (channel: string, message: string) => {});
+
+// const getChannelsNameFromDocumentNode = (document: DocumentNode): string[] => {
+//   const [definition] = document.definitions;
+//   const {
+//     //@ts-ignore
+//     selectionSet: {
+//       selections: [selection]
+//     }
+//   } = definition;
+
+//   const {
+//     arguments: [argument]
+//   } = selection;
+
+//   const {
+//     value: { values: channels }
+//   } = argument;
+
+//   return channels.map(data => data.value);
+// };
+
+// const getChannelNameFromWebSocketMessage = (
+//   message: string
+// ): string[] | undefined => {
+//   try {
+//     const message_ = JSON.parse(message);
+//     if (!message_.payload) return;
+//     const document = gql`
+//       ${message_.payload.query}
+//     ` as DocumentNode;
+//     const channelName = getChannelsNameFromDocumentNode(document);
+//     return channelName;
+//   } catch (err) {
+//     return;
+//   }
+// };
+
+const COMPLETE_MESSAGE = {
+  type: "complete",
+  id: 1
+};
+
+const onUnsubscribeHandler = (webSocket: WebSocket) => (
+  channel: string,
+  message: any
+) => {
+  // try {
+  //   console.log(channel);
+  //   webSocket.send(JSON.stringify(COMPLETE_MESSAGE));
+  //   redwigsSubscriber.unsubscribe(
+  //     [REDWIGS_REDIS_UNSUBSCRIBE_ALL, channel].join(":")
+  //   );
+  // } catch (err) {
+  //   throw new Error(err);
+  // }
+};
+
+// const onWebsocketMessage = (message: string) => {
+//   try {
+//     const channels: string[] = getChannelNameFromWebSocketMessage(message);
+//     if (!channels) return;
+//     const unsubscribeWatcherChannelName = channels.map(channel =>
+//       [REDWIGS_REDIS_UNSUBSCRIBE_ALL, channel].join(":")
+//     );
+
+//     redwigsSubscriber.subscribe(...unsubscribeWatcherChannelName);
+//   } catch (err) {
+//     throw new Error(err);
+//   }
+// };
+
+export const onSubscriptionConnect = (
+  connectionParams: object,
+  websocket: WebSocket,
+  context: ConnectionContext
+): any => {};
+
+export const onSubscriptionDisconnect = (webSocket, context) => {
+  // console.log("disconnect");
+  // onWebsocketMessage(webSocket);
+};

--- a/graphql-server/src/scopes/commands/index.ts
+++ b/graphql-server/src/scopes/commands/index.ts
@@ -42,6 +42,11 @@ import {
   typeDefs as sortedSetsTypeDefs
 } from "./sortedsets";
 
+import {
+  resolvers as pubsubCommandResolver,
+  typeDefs as pubsubsTypeDefs
+} from "./pubsub";
+
 const redisRootTypeDefs = gql`
   scalar OK
   scalar Errors
@@ -84,7 +89,8 @@ export const typeDefs = [
   ...geoTypeDefs,
   ...hyperLogLogTypeDefs,
   ...listTypeDefs,
-  ...sortedSetsTypeDefs
+  ...sortedSetsTypeDefs,
+  ...pubsubsTypeDefs
 ];
 
 export const resolvers = {
@@ -97,7 +103,8 @@ export const resolvers = {
     ...geoCommandResolver.Query,
     ...hyperLogLogCommandResolver.Query,
     ...listCommandResolver.Query,
-    ...sortedSetsCommandResolver.Query
+    ...sortedSetsCommandResolver.Query,
+    ...pubsubCommandResolver.Query
   },
   Mutation: {
     ...stringCommandResolvers.mutation,
@@ -108,9 +115,12 @@ export const resolvers = {
     ...geoCommandResolver.Mutation,
     ...hyperLogLogCommandResolver.Mutation,
     ...listCommandResolver.Mutation,
-    ...sortedSetsCommandResolver.Mutation
+    ...sortedSetsCommandResolver.Mutation,
+    ...pubsubCommandResolver.Mutation
   },
-  Subscription: {},
+  Subscription: {
+    ...pubsubCommandResolver.Subscription
+  },
   ...keysCommandResolver.types,
   ...customScalarResolver
 };

--- a/graphql-server/src/scopes/commands/pubsub/index.ts
+++ b/graphql-server/src/scopes/commands/pubsub/index.ts
@@ -1,0 +1,23 @@
+import { typeDefs as pubsubTypeDefs, _pubsub } from "./pubsub";
+import { typeDefs as publishTypeDefs, _publish } from "./publish";
+import { typeDefs as subscribeTypeDefs, _subscribe } from "./subscribe";
+import { typeDefs as psubscribeTypeDefs, _psubscribe } from "./psubscribe";
+import { typeDefs as unsubscribeTypeDefs, _unsubscribe } from "./unsubscribe";
+import {
+  typeDefs as punsubscribeTypeDefs,
+  _punsubscribe
+} from "./punsubscribe";
+
+export const typeDefs = [
+  pubsubTypeDefs,
+  publishTypeDefs,
+  subscribeTypeDefs,
+  unsubscribeTypeDefs,
+  psubscribeTypeDefs,
+  punsubscribeTypeDefs
+];
+export const resolvers = {
+  Query: { _pubsub },
+  Mutation: { _publish, _unsubscribe, _punsubscribe },
+  Subscription: { _subscribe, _psubscribe }
+};

--- a/graphql-server/src/scopes/commands/pubsub/psubscribe.ts
+++ b/graphql-server/src/scopes/commands/pubsub/psubscribe.ts
@@ -1,0 +1,130 @@
+import gql from "graphql-tag";
+import {
+  pubsub,
+  subscriber
+} from "@adapters/pubsub";
+import { withFilter } from "apollo-server";
+import __ from "lodash";
+import { redwigsClient, REDWIGS_PUBSUB_CHANNEL_DATA, REDWIGS_REDIS_PATTERN_PUBSUB } from "@adapters/redwigs";
+import { ScanType } from "../keys/scan";
+import { parseJSONOrKeep, convertToJSONOrKeep } from "@utils/json";
+import delay from "delay";
+import {
+  transformMerge,
+  transformPairToParsedJSON,
+  arrayToObjectNull
+} from "@utils/collections";
+
+export type PSubscribeArgs = {
+  patterns: string[];
+};
+
+export type PSubscribePayload = {
+  _psubscribe: {
+    pattern: string;
+    channel: string;
+    message: any | null;
+    isFirstTime?: boolean;
+  };
+};
+
+const replyInitialSubscription = async (patterns: string[]) => {
+  await delay(50);
+  pubsub.publish(REDWIGS_REDIS_PATTERN_PUBSUB, {
+    _psubscribe: {
+      isFirstTime: true
+    }
+  });
+};
+
+const resolve = async (
+  {
+    _psubscribe: { pattern, channel, message, isFirstTime }
+  }: PSubscribePayload,
+  { patterns }: PSubscribeArgs
+): Promise<any> => {
+  if (isFirstTime && isFirstTime === true) {
+    return __.transform(patterns, arrayToObjectNull, {});
+  }
+
+  const hscans = patterns.map(_pattern =>
+    redwigsClient.send_command(
+      ScanType.HSCAN,
+      ...[REDWIGS_PUBSUB_CHANNEL_DATA, 0, "MATCH", _pattern]
+    )
+  );
+
+  const reply = await Promise.all(hscans);
+  const patternScanPair = __.zipObject(patterns, reply);
+
+  const toChannelParsedValuePair = (result: any, value: any, key: any) => {
+    const [channel, message] = value;
+    result[channel] = parseJSONOrKeep(message);
+  };
+
+  const toPatternResults = (result: any, value: any, key: any) => {
+    const [, scanResult] = patternScanPair[pattern];
+    const parsedResult = __.chain(scanResult)
+      .chunk(2)
+      .transform(toChannelParsedValuePair, {})
+      .value();
+
+    result[key] = parsedResult;
+  };
+
+  const scanResult = __.transform(patternScanPair, toPatternResults, {});
+  const parsedMessage = parseJSONOrKeep(message);
+  const previousMessage = scanResult[pattern][channel];
+  const equalWithPreviousValue = __.isEqual(previousMessage, parsedMessage);
+  if (!equalWithPreviousValue) {
+    const reply = await redwigsClient.hset(
+      REDWIGS_PUBSUB_CHANNEL_DATA,
+      channel,
+      convertToJSONOrKeep(message)
+    );
+
+    scanResult[pattern][channel] = parsedMessage;
+  }
+
+  return scanResult;
+};
+
+const asyncIteratorFn = (
+  _,
+  { patterns }: PSubscribeArgs
+): AsyncIterator<any> => {
+  try {
+    subscriber.psubscribe(...patterns);
+    return pubsub.asyncIterator(REDWIGS_REDIS_PATTERN_PUBSUB);
+  } finally {
+    replyInitialSubscription(patterns);
+  }
+};
+
+const passFilter = (
+  patterns: string[],
+  { _psubscribe: { pattern, isFirstTime } }: PSubscribePayload
+): boolean => isFirstTime || patterns.includes(pattern);
+
+const filterFn = async (
+  payload: PSubscribePayload,
+  { patterns }: PSubscribeArgs
+): Promise<boolean> => passFilter(patterns, payload);
+
+const subscribe = withFilter(asyncIteratorFn, filterFn);
+export const _psubscribe = {
+  resolve,
+  subscribe
+};
+
+export const typeDefs = gql`
+  extend type Subscription {
+    """
+    **PSUBSCRIBE pattern [pattern ...]**
+
+    Listen for messages published to channels matching the given patterns.
+    [Read more >>](https://redis.io/commands/psubscribe)
+    """
+    _psubscribe(patterns: [String!]!): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/pubsub/publish.ts
+++ b/graphql-server/src/scopes/commands/pubsub/publish.ts
@@ -1,0 +1,36 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+import { convertToJSONOrKeep } from "@utils/json";
+
+export type PublishArgs = {
+  channel: string;
+  message: any;
+};
+
+export const _publish: ResolverFunction<PublishArgs> = async (
+  root,
+  { channel, message },
+  ctx,
+  info
+): Promise<IntResp> => {
+  try {
+    const msg = convertToJSONOrKeep(message);
+    const reply = await redisClient.publish(channel, msg);
+
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **PUBLISH channel message**
+
+    Post a message to a channel. [Read more >>](https://redis.io/commands/publish)
+    """
+    _publish(channel: String!, message: JSON!): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/pubsub/pubsub.ts
+++ b/graphql-server/src/scopes/commands/pubsub/pubsub.ts
@@ -1,0 +1,66 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+import _ from "lodash";
+import { transformMerge } from "@utils/collections";
+
+export enum PubSubCommand {
+  CHANNELS = "CHANNELS",
+  NUMSUB = "NUMSUB",
+  NUMPAT = "NUMPAT"
+}
+
+export type PubsubArgs = {
+  subcommand: PubSubCommand;
+  arguments?: string[];
+};
+
+export const _pubsub: ResolverFunction<PubsubArgs> = async (
+  root,
+  { subcommand, arguments: subarguments },
+  ctx
+): Promise<any> => {
+  try {
+    const args: any[] = [subcommand];
+    if (subcommand === PubSubCommand.CHANNELS) {
+      if (subarguments && subarguments.length === 1) args.push(subarguments[0]);
+    }
+
+    if (subcommand === PubSubCommand.NUMSUB) {
+      if (subarguments && subarguments.length >= 1) args.push(...subarguments);
+    }
+
+    const reply = await redisClient.send_command("PUBSUB", ...args);
+    if (subcommand === PubSubCommand.CHANNELS) {
+      return reply.filter(v => !v.match(new RegExp("redwigs:redis")));
+    }
+
+    if (subcommand === PubSubCommand.NUMSUB) {
+      return transformMerge(reply, 2, ([channel, count]) => ({
+        [channel]: count
+      }));
+    }
+
+    return reply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  enum PubSubCommand {
+    CHANNELS
+    NUMSUB
+    NUMPAT
+  }
+
+  extend type Query {
+    """
+    **PUBSUB subcommand [argument [argument ...]]**
+
+    Inspect the state of the Pub/Sub subsystem.
+    [Read more >>](https://redis.io/commands/pubsub)
+    """
+    _pubsub(subcommand: PubSubCommand!, arguments: [String]): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/pubsub/punsubscribe.ts
+++ b/graphql-server/src/scopes/commands/pubsub/punsubscribe.ts
@@ -1,0 +1,78 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redwigsClient, REDWIGS_PUBSUB_CHANNEL_DATA } from "@adapters/redwigs";
+import { subscriber } from "@adapters/pubsub";
+import { redisClient } from "@adapters/redis";
+import uniq from "lodash/uniq";
+
+export type PUnsubscribeArgs = {
+  patterns?: string[];
+};
+
+const unsubscribeAll = async (): Promise<any> => {
+  const allChannels: string[] = await redwigsClient.send_command(
+    "PUBSUB",
+    "CHANNELS"
+  );
+
+  await redwigsClient.hdel(REDWIGS_PUBSUB_CHANNEL_DATA, ...allChannels);
+
+  const redisClientMulti = redisClient.multi();
+  allChannels.forEach(channel => redisClientMulti.publish(channel, "null"));
+  await redisClientMulti.exec();
+
+  const unsubsWithoutChannelReply = await subscriber.unsubscribe(
+    ...allChannels
+  );
+
+  return unsubsWithoutChannelReply;
+};
+
+export const _punsubscribe: ResolverFunction<PUnsubscribeArgs> = async (
+  root,
+  { patterns }
+): Promise<IntResp> => {
+  try {
+    if (!patterns) return await unsubscribeAll();
+
+    const allChannelsWithPatternsReq = patterns.map(pattern =>
+      redisClient.send_command("PUBSUB", "CHANNELS", pattern)
+    );
+
+    const allChannelsMatchedPatterns = await Promise.all(
+      allChannelsWithPatternsReq
+    );
+
+    const uniqOfAllChannelsMatchedPatterns = uniq(
+      allChannelsMatchedPatterns.flat()
+    );
+
+    const redwigsClientMulti = redwigsClient.multi();
+    const redisClientMulti = redisClient.multi();
+    uniqOfAllChannelsMatchedPatterns.forEach(channel => {
+      redwigsClientMulti.hdel(REDWIGS_PUBSUB_CHANNEL_DATA, channel);
+      redisClientMulti.publish(channel, "null");
+    });
+
+    await redwigsClientMulti.exec();
+    await subscriber.punsubscribe(...patterns);
+    const unsubsReply = await subscriber.unsubscribe(
+      ...uniqOfAllChannelsMatchedPatterns
+    );
+    return unsubsReply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **PUNSUBSCRIBE [pattern [pattern ...]]**
+
+    Stop listening for messages posted to channels matching the given patterns.
+    [Read more >>](https://redis.io/commands/punsubscribe)
+    """
+    _punsubscribe(patterns: [String]): Int
+  }
+`;

--- a/graphql-server/src/scopes/commands/pubsub/subscribe.ts
+++ b/graphql-server/src/scopes/commands/pubsub/subscribe.ts
@@ -1,0 +1,109 @@
+import gql from "graphql-tag";
+import { pubsub, subscriber } from "@adapters/pubsub";
+import { withFilter } from "apollo-server";
+import { parseJSONOrKeep, convertToJSONOrKeep } from "@utils/json";
+import __ from "lodash";
+import {
+  redwigsClient,
+  REDWIGS_PUBSUB_CHANNEL_DATA,
+  REDWIGS_REDIS_PUBSUB
+} from "@adapters/redwigs";
+import delay from "delay";
+import { parseValueToJSONTransformer } from "@utils/collections";
+
+export type SubscribeArgs = {
+  channels: string[];
+};
+
+export type SubscribePayload = {
+  _subscribe: {
+    channel: string;
+    message: string;
+    isFirstTime?: boolean;
+  };
+};
+
+const replyInitialSubscription = async (channels: string[]) => {
+  try {
+    await delay(50);
+    pubsub.publish(REDWIGS_REDIS_PUBSUB, {
+      _subscribe: { isFirstTime: true }
+    });
+  } catch (error) {
+    throw new Error(error);
+  }
+};
+
+const resolve = async (
+  { _subscribe: { channel, message } }: SubscribePayload,
+  { channels }: SubscribeArgs
+): Promise<any> => {
+  try {
+    const reply = await redwigsClient.hmget(
+      REDWIGS_PUBSUB_CHANNEL_DATA,
+      ...channels
+    );
+
+    const previousValue = __.chain(channels)
+      .zipObject(reply)
+      .transform(parseValueToJSONTransformer, {})
+      .value();
+
+    const parsedMessage = parseJSONOrKeep(message);
+    const previousMessage = previousValue[channel];
+    const equalWithPreviousValue = __.isEqual(parsedMessage, previousMessage);
+
+    if (!equalWithPreviousValue) {
+      const reply = await redwigsClient.hset(
+        REDWIGS_PUBSUB_CHANNEL_DATA,
+        channel,
+        convertToJSONOrKeep(message)
+      );
+      previousValue[channel] = parsedMessage;
+    }
+
+    return previousValue;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+const asyncIteratorFn = (
+  _,
+  { channels }: SubscribeArgs
+): AsyncIterator<any> => {
+  try {
+    subscriber.subscribe(...channels);
+    return pubsub.asyncIterator(REDWIGS_REDIS_PUBSUB);
+  } finally {
+    replyInitialSubscription(channels);
+  }
+};
+
+const passFilter = (
+  channels: string[],
+  { _subscribe: { channel, isFirstTime } }: SubscribePayload
+): boolean => isFirstTime || channels.includes(channel);
+
+const filterFn = async (
+  payload: SubscribePayload,
+  { channels }: SubscribeArgs
+): Promise<boolean> => passFilter(channels, payload);
+
+const subscribe = withFilter(asyncIteratorFn, filterFn);
+export const _subscribe = {
+  resolve,
+  subscribe
+};
+
+export const typeDefs = gql`
+  extend type Subscription {
+    """
+    **SUBSCRIBE channel [channel...]**
+
+    Listen for messages published to the given channels.
+    [Read more >>](https://redis.io/commands/subscribe)
+    """
+    _subscribe(channels: [String!]!): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/pubsub/unsubscribe.ts
+++ b/graphql-server/src/scopes/commands/pubsub/unsubscribe.ts
@@ -1,0 +1,63 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redwigsClient, REDWIGS_PUBSUB_CHANNEL_DATA } from "@adapters/redwigs";
+import { subscriber } from "@adapters/pubsub";
+import { redisClient } from "@adapters/redis";
+
+export type UnsubscribeArgs = {
+  channels?: string[];
+};
+
+const unsubscribeAll = async (): Promise<any> => {
+  const allChannels: string[] = await redwigsClient.send_command(
+    "PUBSUB",
+    "CHANNELS"
+  );
+
+  await redwigsClient.hdel(REDWIGS_PUBSUB_CHANNEL_DATA, ...allChannels);
+
+  const redisClientMulti = redisClient.multi();
+  allChannels.forEach(channel => redisClientMulti.publish(channel, "null"));
+  await redisClientMulti.exec();
+
+  const unsubsWithoutChannelReply = await subscriber.unsubscribe(
+    ...allChannels
+  );
+
+  return unsubsWithoutChannelReply;
+};
+
+export const _unsubscribe: ResolverFunction<UnsubscribeArgs> = async (
+  root,
+  { channels }
+): Promise<IntResp> => {
+  try {
+    if (!channels) return await unsubscribeAll();
+
+    const redisClientMulti = redisClient.multi();
+    const redwigsClientMulti = redwigsClient.multi();
+    channels.forEach(channel => {
+      redwigsClientMulti.hdel(REDWIGS_PUBSUB_CHANNEL_DATA, channel);
+      redisClientMulti.publish(channel, "null");
+    });
+
+    await redwigsClientMulti.exec();
+    await redisClientMulti.exec();
+    const unsubsReply = await subscriber.unsubscribe(...channels);
+    return unsubsReply;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **UNSUBSCRIBE [channel [channel ...]]**
+
+    Stop listening for messages posted to the given channels.
+    [Read more >>](https://redis.io/commands/unsubscribe)
+    """
+    _unsubscribe(channels: [String]): Int
+  }
+`;

--- a/graphql-server/src/utils/collections.ts
+++ b/graphql-server/src/utils/collections.ts
@@ -1,0 +1,32 @@
+import _ from "lodash";
+import { parseJSONOrKeep } from "./json";
+
+export const transformPairToParsedJSON = ([key, value]) => ({
+  [key]: parseJSONOrKeep(value)
+});
+
+export const arrayToObjectNull = (result: any, value: string, key: number) => {
+  result[value] = null;
+};
+
+export const parseValueToJSONTransformer = (
+  result: any,
+  value: any,
+  key: string
+) => {
+  result[key] = parseJSONOrKeep(value);
+};
+
+export const transformMerge = <T, U>(
+  array: any[],
+  pairChunk: number,
+  callbackfn: (value: T, index: number, array: T[]) => U
+) => {
+  return _.merge(
+    {},
+    ..._.chain(array)
+      .chunk(pairChunk)
+      .map(callbackfn)
+      .value()
+  );
+};

--- a/graphql-server/src/utils/subscribe.ts
+++ b/graphql-server/src/utils/subscribe.ts
@@ -1,0 +1,42 @@
+import {
+  DocumentNode,
+  OperationDefinitionNode,
+  FieldNode,
+  ListValueNode,
+  StringValueNode
+} from "graphql";
+import gql from "graphql-tag";
+
+export const getChannelNamesFromQuery = (
+  query: string | DocumentNode,
+  variables: any
+) => {
+  const queryNode: DocumentNode = gql`
+    ${query}
+  `;
+
+  const [firstDefinition] = queryNode.definitions;
+  const subscription = firstDefinition as OperationDefinitionNode;
+  const { operation } = subscription;
+
+  if (operation !== "subscription") {
+    return [];
+  }
+
+  if (subscription.variableDefinitions.length > 0) {
+    const {
+      variableDefinitions: [channelsArg]
+    } = subscription;
+    const channelsVariableName = channelsArg.variable.name.value;
+    const channelNames = variables[channelsVariableName];
+    return channelNames;
+  }
+
+  const [firstField] = subscription.selectionSet.selections;
+  const subscriptionField = firstField as FieldNode;
+  const [firstArgument] = subscriptionField.arguments;
+  const argumentList = firstArgument.value as ListValueNode;
+  const channelNames = argumentList.values.map((v: StringValueNode) => v.value);
+
+  return channelNames;
+};

--- a/graphql-server/tsconfig.json
+++ b/graphql-server/tsconfig.json
@@ -10,6 +10,7 @@
     "paths": {
       "@scopes/*": ["scopes/*"],
       "@adapters/*": ["adapters/*"],
+      "@handlers/*": ["handlers/*"],
       "@utils/*": ["utils/*"],
       "@typings": ["typings"]
     }

--- a/graphql-server/yarn.lock
+++ b/graphql-server/yarn.lock
@@ -319,6 +319,14 @@ apollo-datasource@^0.6.4:
     apollo-server-caching "^0.5.1"
     apollo-server-env "^2.4.3"
 
+apollo-datasource@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/apollo-datasource/-/apollo-datasource-0.7.0.tgz#2a6d82edb2eba21b4ddf21877009ba39ff821945"
+  integrity sha512-Yja12BgNQhzuFGG/5Nw2MQe0hkuQy2+9er09HxeEyAf2rUDIPnhPrn1MDoZTB8MU7UGfjwITC+1ofzKkkrZobA==
+  dependencies:
+    apollo-server-caching "^0.5.1"
+    apollo-server-env "^2.4.3"
+
 apollo-engine-reporting-protobuf@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.4.tgz#73a064f8c9f2d6605192d1673729c66ec47d9cb7"
@@ -333,6 +341,20 @@ apollo-engine-reporting@^1.4.14:
   dependencies:
     apollo-engine-reporting-protobuf "^0.4.4"
     apollo-graphql "^0.3.7"
+    apollo-server-caching "^0.5.1"
+    apollo-server-env "^2.4.3"
+    apollo-server-errors "^2.3.4"
+    apollo-server-types "^0.2.10"
+    async-retry "^1.2.1"
+    graphql-extensions "^0.10.10"
+
+apollo-engine-reporting@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/apollo-engine-reporting/-/apollo-engine-reporting-1.5.0.tgz#6e3746de14fc87e14c289c0776a2d350e6f50918"
+  integrity sha512-Pe2DelijZ2QHqkqv8E97iOb32l+FIMT2nxpQsuH+nWi+96cCFJJJHjm3RLAPEUuvGOgW9dFYQP3J91EyC5O0tQ==
+  dependencies:
+    apollo-engine-reporting-protobuf "^0.4.4"
+    apollo-graphql "^0.4.0"
     apollo-server-caching "^0.5.1"
     apollo-server-env "^2.4.3"
     apollo-server-errors "^2.3.4"
@@ -358,6 +380,14 @@ apollo-graphql@^0.3.7:
     apollo-env "^0.6.1"
     lodash.sortby "^4.7.0"
 
+apollo-graphql@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/apollo-graphql/-/apollo-graphql-0.4.0.tgz#dd0afe31a6241b8e2ded20b906c9ee8dfbe03497"
+  integrity sha512-abCHcKln1EGbzSItW087EjBI5wnluikyUqEn4VsdeWHCtdENWpHCn/MnM0+jJa1prNasxN7tCukp4nMpJYYVqg==
+  dependencies:
+    apollo-env "^0.6.1"
+    lodash.sortby "^4.7.0"
+
 apollo-link@^1.2.3:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.13.tgz#dff00fbf19dfcd90fddbc14b6a3f9a771acac6c4"
@@ -374,6 +404,33 @@ apollo-server-caching@^0.5.1:
   integrity sha512-L7LHZ3k9Ao5OSf2WStvQhxdsNVplRQi7kCAPfqf9Z3GBEnQ2uaL0EgO0hSmtVHfXTbk5CTRziMT1Pe87bXrFIw==
   dependencies:
     lru-cache "^5.0.0"
+
+apollo-server-core@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.10.0.tgz#b8d51bdffe6529f0e3ca670ee8f1238765cfade4"
+  integrity sha512-x/UK6XvU307W8D/pzTclU04JIjRarcbg5mFPe0nVmO4OTc26uQgKi1WlZkcewXsAUnn+nDwKVn2c2G3dHEgXzQ==
+  dependencies:
+    "@apollographql/apollo-tools" "^0.4.3"
+    "@apollographql/graphql-playground-html" "1.6.24"
+    "@types/graphql-upload" "^8.0.0"
+    "@types/ws" "^6.0.0"
+    apollo-cache-control "^0.8.11"
+    apollo-datasource "^0.7.0"
+    apollo-engine-reporting "^1.5.0"
+    apollo-server-caching "^0.5.1"
+    apollo-server-env "^2.4.3"
+    apollo-server-errors "^2.3.4"
+    apollo-server-plugin-base "^0.6.10"
+    apollo-server-types "^0.2.10"
+    apollo-tracing "^0.8.11"
+    fast-json-stable-stringify "^2.0.0"
+    graphql-extensions "^0.10.10"
+    graphql-tag "^2.9.2"
+    graphql-tools "^4.0.0"
+    graphql-upload "^8.0.2"
+    sha.js "^2.4.11"
+    subscriptions-transport-ws "^0.9.11"
+    ws "^6.0.0"
 
 apollo-server-core@^2.9.16:
   version "2.9.16"
@@ -414,6 +471,28 @@ apollo-server-errors@^2.3.4:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.3.4.tgz#b70ef01322f616cbcd876f3e0168a1a86b82db34"
   integrity sha512-Y0PKQvkrb2Kd18d1NPlHdSqmlr8TgqJ7JQcNIfhNDgdb45CnqZlxL1abuIRhr8tiw8OhVOcFxz2KyglBi8TKdA==
+
+apollo-server-express@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-2.10.0.tgz#7d87ff54e378cdcb135eb3d093f20fca7fc0d1bc"
+  integrity sha512-adDQts4QmkX2ENU7JibV1EwRl3ESnpnpImXIMvg8Cm7kX2wSbzwm8LecQNujwWJtkAPTCEAcnPBDyKwWjTQ6/g==
+  dependencies:
+    "@apollographql/graphql-playground-html" "1.6.24"
+    "@types/accepts" "^1.3.5"
+    "@types/body-parser" "1.17.1"
+    "@types/cors" "^2.8.4"
+    "@types/express" "4.17.2"
+    accepts "^1.3.5"
+    apollo-server-core "^2.10.0"
+    apollo-server-types "^0.2.10"
+    body-parser "^1.18.3"
+    cors "^2.8.4"
+    express "^4.17.1"
+    graphql-subscriptions "^1.0.0"
+    graphql-tools "^4.0.0"
+    parseurl "^1.3.2"
+    subscriptions-transport-ws "^0.9.16"
+    type-is "^1.6.16"
 
 apollo-server-express@^2.9.16:
   version "2.9.16"
@@ -664,6 +743,11 @@ define-properties@^1.1.2, define-properties@^1.1.3:
   dependencies:
     object-keys "^1.0.12"
 
+delay@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/delay/-/delay-4.3.0.tgz#efeebfb8f545579cb396b3a722443ec96d14c50e"
+  integrity sha512-Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA==
+
 denque@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
@@ -886,6 +970,15 @@ graphql-extensions@^0.10.10:
     apollo-server-env "^2.4.3"
     apollo-server-types "^0.2.10"
 
+graphql-redis-subscriptions@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/graphql-redis-subscriptions/-/graphql-redis-subscriptions-2.1.2.tgz#9c1b744bace0c6ba99dd0ebafe0148cad1df3301"
+  integrity sha512-l69KbGxyYfVHxvE+Dzv9/hXg/q+Xnjfx1JsrJD6ikePuSsNaCSNxr+MubSTNF3Gt3C/+JZs4FaWImFeK/+X2og==
+  dependencies:
+    iterall "^1.2.2"
+  optionalDependencies:
+    ioredis "^4.6.3"
+
 graphql-scalars@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/graphql-scalars/-/graphql-scalars-1.0.6.tgz#7fd9bcc51116f9cebb03a27508d8e5b605675f92"
@@ -893,7 +986,7 @@ graphql-scalars@^1.0.6:
   dependencies:
     "@types/node" "12.12.24"
 
-graphql-subscriptions@^1.0.0:
+graphql-subscriptions@^1.0.0, graphql-subscriptions@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz#5f2fa4233eda44cf7570526adfcf3c16937aef11"
   integrity sha512-6WzlBFC0lWmXJbIVE8OgFgXIP4RJi3OQgTPa0DVMsDXdpRDjTsM1K9wfl5HSYX7R87QAGlvcv2Y4BIZa/ItonA==
@@ -1021,7 +1114,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ioredis@^4.14.1:
+ioredis@^4.14.1, ioredis@^4.6.3:
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.14.1.tgz#b73ded95fcf220f106d33125a92ef6213aa31318"
   integrity sha512-94W+X//GHM+1GJvDk6JPc+8qlM7Dul+9K+lg3/aHixPN7ZGkW6qlvX0DG6At9hWtH2v3B32myfZqWoANUJYGJA==


### PR DESCRIPTION
This PR supports Redis PubSub over GraphQL.

Also include preliminary subscription implementation of GraphQL. This is important for future implementation of some Redis commands subscription 