### PR TITLE
graphql-server/feat: Add Redis Scripting commands to GraphQL

### DIFF
--- a/graphql-server/src/app.ts
+++ b/graphql-server/src/app.ts
@@ -19,7 +19,7 @@ const PORT = 4000;
 const app = express();
 const httpServer = http.createServer(app);
 
-app.use("/", (req: Request, res: Response) =>
+app.get("/", (req: Request, res: Response) =>
   res
     .status(404)
     .send({ message: "Resource Not Found", endpoints: { graphql: "/graphql" } })

--- a/graphql-server/src/scopes/commands/index.ts
+++ b/graphql-server/src/scopes/commands/index.ts
@@ -47,6 +47,11 @@ import {
   typeDefs as pubsubsTypeDefs
 } from "./pubsub";
 
+import {
+  resolvers as scriptingCommandResolvers,
+  typeDefs as scriptingTypeDefs
+} from "./scripting";
+
 const redisRootTypeDefs = gql`
   scalar OK
   scalar Errors
@@ -90,7 +95,8 @@ export const typeDefs = [
   ...hyperLogLogTypeDefs,
   ...listTypeDefs,
   ...sortedSetsTypeDefs,
-  ...pubsubsTypeDefs
+  ...pubsubsTypeDefs,
+  ...scriptingTypeDefs
 ];
 
 export const resolvers = {
@@ -104,7 +110,8 @@ export const resolvers = {
     ...hyperLogLogCommandResolver.Query,
     ...listCommandResolver.Query,
     ...sortedSetsCommandResolver.Query,
-    ...pubsubCommandResolver.Query
+    ...pubsubCommandResolver.Query,
+    ...scriptingCommandResolvers.Query
   },
   Mutation: {
     ...stringCommandResolvers.mutation,
@@ -116,7 +123,8 @@ export const resolvers = {
     ...hyperLogLogCommandResolver.Mutation,
     ...listCommandResolver.Mutation,
     ...sortedSetsCommandResolver.Mutation,
-    ...pubsubCommandResolver.Mutation
+    ...pubsubCommandResolver.Mutation,
+    ...scriptingCommandResolvers.Mutation
   },
   Subscription: {
     ...pubsubCommandResolver.Subscription

--- a/graphql-server/src/scopes/commands/scripting/eval.ts
+++ b/graphql-server/src/scopes/commands/scripting/eval.ts
@@ -1,0 +1,43 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type EvalArgs = {
+  script: string;
+  numkeys: number;
+  keys: string[];
+  args: string[];
+};
+
+export const _eval: ResolverFunction<EvalArgs> = async (
+  root,
+  { script, numkeys, keys, args },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const finalArgs = [script, numkeys];
+    if (keys) finalArgs.push(...keys);
+    if (args) finalArgs.push(...args);
+
+    const result = await redisClient.send_command("EVAL", ...finalArgs);
+    return result;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  extend type Mutation {
+    """
+    **EVAL script numkeys key [key ...] arg [arg ...]**
+
+    Execute a Lua script server side. [Read more >>](https://redis.io/commands/eval)
+    """
+    _eval(
+      script: String!
+      numkeys: Int!
+      keys: [String!]
+      args: [String!]
+    ): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/scripting/evalsha.ts
+++ b/graphql-server/src/scopes/commands/scripting/evalsha.ts
@@ -1,0 +1,36 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import { redisClient } from "@adapters/redis";
+
+export type EvalSHAArgs = {
+  sha1: string;
+  numkeys: number;
+  keys: string[];
+  args: string[];
+};
+
+export const _evalsha: ResolverFunction<EvalSHAArgs> = async (
+  root,
+  { sha1, numkeys, keys, args },
+  ctx
+): Promise<any> => {
+  const result = await redisClient.evalsha(sha1, numkeys, ...keys, ...args);
+
+  return result;
+};
+
+export const typeDefs = gql`
+  extend type Query {
+    """
+    **EVALSHA sha1 numkeys key [key ...] arg [arg ...]**
+
+    Execute a Lua script server side. [Read more >>](https://redis.io/commands/evalsha)
+    """
+    _evalsha(
+      sha1: String!
+      numkeys: Int!
+      keys: [String!]!
+      args: [String!]!
+    ): JSON
+  }
+`;

--- a/graphql-server/src/scopes/commands/scripting/index.ts
+++ b/graphql-server/src/scopes/commands/scripting/index.ts
@@ -1,0 +1,27 @@
+import { typeDefs as evalTypeDefs, _eval } from "./eval";
+import { typeDefs as evalSHATypeDefs, _evalsha } from "./evalsha";
+import {
+  typeDefs as scriptTypeDefs,
+  _script_debug,
+  _script_exists,
+  _script_flush,
+  _script_kill,
+  _script_load
+} from "./script";
+
+export const typeDefs = [evalTypeDefs, scriptTypeDefs, evalSHATypeDefs];
+
+export const resolvers = {
+  Query: {
+    _script_exists,
+    _evalsha
+  },
+  Mutation: {
+    _eval,
+    _script_debug,
+    _script_flush,
+    _script_kill,
+    _script_load
+  },
+  Subscription: {}
+};

--- a/graphql-server/src/scopes/commands/scripting/script.ts
+++ b/graphql-server/src/scopes/commands/scripting/script.ts
@@ -1,0 +1,133 @@
+import gql from "graphql-tag";
+import { ResolverFunction, IntResp } from "@typings";
+import zipObject from "lodash/zipObject";
+import { redisClient } from "@adapters/redis";
+
+export type ScriptLoadArgs = {
+  script: string;
+};
+
+export type ScriptExistsArgs = {
+  sha1: string[];
+};
+
+export enum DebugOptions {
+  YES = "YES",
+  SYNC = "SYNC",
+  NO = "NO"
+}
+
+export type ScriptDebugArgs = {
+  options: DebugOptions;
+};
+
+export const _script_load: ResolverFunction<ScriptLoadArgs> = async (
+  root,
+  { script },
+  ctx
+): Promise<IntResp> => {
+  try {
+    const result = await redisClient.send_command("SCRIPT", "LOAD", script);
+    return result;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const _script_exists: ResolverFunction<ScriptExistsArgs> = async (
+  root,
+  { sha1 },
+  ctx
+): Promise<any> => {
+  try {
+    const result = await redisClient.send_command("SCRIPT", "EXISTS", ...sha1);
+    return zipObject(
+      sha1,
+      result.map((v: number) => (v === 1 ? true : false))
+    );
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const _script_debug: ResolverFunction<ScriptDebugArgs> = async (
+  root,
+  { options }
+): Promise<any> => {
+  try {
+    const result = await redisClient.send_command("SCRIPT", "DEBUG", options);
+    return result;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const _script_flush: ResolverFunction<any> = async (): Promise<string> => {
+  try {
+    const result = await redisClient.send_command("SCRIPT", "FLUSH");
+    return result;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const _script_kill: ResolverFunction<any> = async (): Promise<string> => {
+  try {
+    const result = await redisClient.send_command("SCRIPT", "KILL");
+    return result;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const typeDefs = gql`
+  enum DebugOptions {
+    YES
+    SYNC
+    NO
+  }
+
+  extend type Query {
+    """
+    **SCRIPT EXISTS sha1 [sha1 ...]**
+
+    Check existence of scripts in the script cache..
+    [Read more >>](https://redis.io/commands/script-exists)
+    """
+    _script_exists(sha1: [String!]!): JSON
+  }
+
+  extend type Mutation {
+    """
+    **SCRIPT DEBUG YES|SYNC|NO**
+    Set the debug mode for executed scripts.
+
+    [Read more >>](https://redis.io/commands/script-debug)
+    """
+    _script_debug(options: DebugOptions): JSON
+
+    """
+    **SCRIPT FLUSH**
+    Remove all the scripts from the script cache.
+
+    [Read more >>](https://redis.io/commands/script-flush)
+    """
+    _script_flush: String
+
+    """
+    **SCRIPT KILL**
+    Kill the script currently in execution.
+
+    [Read more >>](https://redis.io/commands/script-kill)
+    """
+    _script_kill: String
+
+    """
+    **SCRIPT LOAD script**
+
+    Load the specified Lua script into the script cache.
+    [Read more >>](https://redis.io/commands/script-load)
+    """
+    _script_load(script: String!): String
+  }
+`;


### PR DESCRIPTION
This PR add implementation of Redis Scripting to GraphQL.

also
- fix express route for GraphQL server, replace use with get

note:
**_Redis script debugger still has a bug. So implementation of Redis debugger to graphql postponed, but mutation using _script_debug works as expected, only after that user must call debug specific commands (not implemented yet)_**